### PR TITLE
feat(a11y): améliorations alt et précision nouvelle fenêtre si target=blank

### DIFF
--- a/src/routes/_homepage/_landing.svelte
+++ b/src/routes/_homepage/_landing.svelte
@@ -83,11 +83,7 @@
   <h2 class="mb-s32 text-center text-france-blue">Comment cela fonctionne</h2>
   <div class="mb-s24 flex flex-col gap-s24 md:flex-row">
     <div class="md:flex-1">
-      <img
-        src={illuRecenser}
-        alt="illustration d'un personnage avec une machine à écrire"
-        class="mb-s16 w-full"
-      />
+      <img src={illuRecenser} alt="" class="mb-s16 w-full" />
       <h3>Recensement de l’offre d’insertion</h3>
       <p class="text-f16">
         Vous proposez des services d'insertion ? Rendez les visibles sur votre
@@ -96,11 +92,7 @@
       </p>
     </div>
     <div class="md:flex-1">
-      <img
-        src={illuMobiliser}
-        alt="illustration d'un ordinateur avec le visage d'un personnage satisfait sur l'écran"
-        class="mb-s16 w-full"
-      />
+      <img src={illuMobiliser} alt="" class="mb-s16 w-full" />
       <h3>Identification du service adapté</h3>
       <p class="text-f16">
         Vous accompagnez des bénéficiaires ? Trouvez rapidement les services
@@ -109,11 +101,7 @@
       </p>
     </div>
     <div class="md:flex-1">
-      <img
-        src={illuAccompagner}
-        alt="illustration avec deux personnages souriants, face à face, chacun dans une bulle qui communiquent avec leur ordinateur."
-        class="mb-s16 w-full"
-      />
+      <img src={illuAccompagner} alt="" class="mb-s16 w-full" />
       <h3>Mobilisation du service</h3>
       <p class="text-f16">
         Vous avez identifié le bon service ? Aidez votre bénéficiaire en

--- a/src/routes/_layout/_footer.svelte
+++ b/src/routes/_layout/_footer.svelte
@@ -14,20 +14,35 @@
   <CenteredGrid>
     <div class="flex gap-s24 lg:flex-row">
       <div class="mb-s24 lg:w-1/2">
-        <img class="inline" src={LogoRF} alt="" width="124" height="110" />
+        <img
+          class="inline"
+          src={LogoRF}
+          alt="République Française - Liberté, Égalité, Fraternité"
+          width="124"
+          height="110"
+        />
       </div>
       <div class="text-f14 leading-normal text-gray-text lg:w-1/2">
         Dora, le service public numérique de recensement et mise à jour de
         l’offre d’insertion.
         <div class="mt-s16 flex flex-wrap gap-x-s24 gap-y-s8 font-bold">
-          <a target="_blank" rel="noopener" href="https://gouvernement.fr"
-            >gouvernement.fr</a
+          <a
+            target="_blank"
+            title="Ouverture dans une nouvelle fenêtre"
+            rel="noopener"
+            href="https://gouvernement.fr">gouvernement.fr</a
           >
-          <a target="_blank" rel="noopener" href="https://service-public.fr"
-            >service-public.fr</a
+          <a
+            target="_blank"
+            title="Ouverture dans une nouvelle fenêtre"
+            rel="noopener"
+            href="https://service-public.fr">service-public.fr</a
           >
-          <a target="_blank" rel="noopener" href="https://data.gouv.fr"
-            >data.gouv.fr</a
+          <a
+            target="_blank"
+            title="Ouverture dans une nouvelle fenêtre"
+            rel="noopener"
+            href="https://data.gouv.fr">data.gouv.fr</a
           >
         </div>
       </div>

--- a/src/routes/_layout/_header.svelte
+++ b/src/routes/_layout/_header.svelte
@@ -21,7 +21,7 @@
           <img
             class="inline"
             src={LogoMinistere}
-            alt="Ministère du Travail, du Plein emploi et de l'Insertion"
+            alt="Ministère du Travail, du Plein emploi et de l’Insertion"
             width="114"
             height="89"
           />

--- a/src/routes/_layout/_header.svelte
+++ b/src/routes/_layout/_header.svelte
@@ -21,12 +21,18 @@
           <img
             class="inline"
             src={LogoMinistere}
-            alt=""
+            alt="Ministère du Travail, du Plein emploi et de l'Insertion"
             width="114"
             height="89"
           />
         </div>
-        <img class="inline" src={LogoDORA} alt="Dora" width="140" height="65" />
+        <img
+          class="inline"
+          src={LogoDORA}
+          alt="Dora - Découvrir, Orienter, Renseigner, Accompagner"
+          width="140"
+          height="65"
+        />
       </a>
       {#if browser}
         <div class="grow" />

--- a/src/routes/auth/registration/_step3-confirm.svelte
+++ b/src/routes/auth/registration/_step3-confirm.svelte
@@ -22,6 +22,7 @@
       <a
         class="underline"
         target="_blank"
+        title="Ouverture dans une nouvelle fenêtre"
         rel="noopener nofollow"
         href="https://itou.typeform.com/doracontactsupp">contactez-nous</a
       >.

--- a/src/routes/contribuer/merci.svelte
+++ b/src/routes/contribuer/merci.svelte
@@ -24,11 +24,7 @@
 <CenteredGrid extraClass="bg-gradient-to-b from-magenta-10 to-magenta-10/0">
   <div class="lg:flex lg:gap-s32">
     <div class="lg:flex-1">
-      <img
-        class="hidden flex-none lg:block"
-        src={ContributionPic}
-        alt="Illustration en bichromie avec un homme et une femme, face à face chacun dans un cercle, en train de prendre des notes, séparéss par des traits horizontaux abstraits, et une main tenant un crayon au premier plan."
-      />
+      <img class="hidden flex-none lg:block" src={ContributionPic} alt="" />
     </div>
     <div class="lg:flex-1">
       <h1 class="text-france-blue">Merci pour votre contribution</h1>

--- a/src/routes/structures/[slug]/_informations.svelte
+++ b/src/routes/structures/[slug]/_informations.svelte
@@ -51,6 +51,7 @@
         </i>
         <a
           target="_blank"
+          title="Ouverture dans une nouvelle fenêtre"
           rel="noopener nofollow"
           href={structure.url}
           class="flex"


### PR DESCRIPTION
- Les attributs `alt` ne doivent être remplis que si l'image est porteuse d'informations ou contient du texte (aka. pas une illustration)
- Il est nécessaire de préciser `title="Ouverture dans une nouvelle fenêtre"` en cas de `target="_blank"`