### PR TITLE
a11y: Niveau titre paramétrable dans les wysiwyg

### DIFF
--- a/src/lib/components/rich-text/editor.svelte
+++ b/src/lib/components/rich-text/editor.svelte
@@ -178,15 +178,15 @@
 
       <Button
         on:click={() =>
-          editor.chain().focus().toggleHeading({ level: 2 }).run()}
-        active={editor.isActive("heading", { level: 2 })}
+          editor.chain().focus().toggleHeading({ level: 1 }).run()}
+        active={editor.isActive("heading", { level: 1 })}
         icon={h1Icon}
       />
 
       <Button
         on:click={() =>
-          editor.chain().focus().toggleHeading({ level: 3 }).run()}
-        active={editor.isActive("heading", { level: 3 })}
+          editor.chain().focus().toggleHeading({ level: 2 }).run()}
+        active={editor.isActive("heading", { level: 2 })}
         icon={h2Icon}
       />
 

--- a/src/lib/components/services/body/presentation/service-description.svelte
+++ b/src/lib/components/services/body/presentation/service-description.svelte
@@ -7,7 +7,7 @@
 </script>
 
 <div class="markdown-wrapper prose mb-s24 w-full">
-  <TextClamp text={markdownToHTML(service.fullDesc)} />
+  <TextClamp text={markdownToHTML(service.fullDesc, 4)} />
 </div>
 
 <style lang="postcss">

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -10,18 +10,14 @@ import { defaultAcceptHeader } from "$lib/utils/api";
 export function markdownToHTML(md, titleLevel) {
   const converter = new showdown.Converter({
     headerLevelStart: titleLevel ?? 2,
-    extensions: [
-      () => ({
-        type: "output",
-        filter(html) {
-          return html.replace(/\bhref=/gi, 'rel="nofollow" href=');
-        },
-      }),
-    ],
   });
 
   return insane(converter.makeHtml(md), {
     allowedAttributes: { a: ["class", "rel", "href"] },
+    filter: (token) => {
+      if (token.tag === "a") token.attrs["rel"] = "nofollow";
+      return token;
+    },
   });
 }
 

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -9,24 +9,11 @@ import { defaultAcceptHeader } from "$lib/utils/api";
 
 export function markdownToHTML(md, titleLevel) {
   const converter = new showdown.Converter({
+    headerLevelStart: titleLevel ?? 2,
     extensions: [
       () => ({
         type: "output",
         filter(html) {
-          if (titleLevel && titleLevel === 3) {
-            // h3 & h4
-            html = html.replace(/h3/gi, "h4");
-            html = html.replace(/h2/gi, "h3");
-          } else if (titleLevel && titleLevel === 4) {
-            // h4 & h5
-            html = html.replace(/h3/gi, "h5");
-            html = html.replace(/h2/gi, "h4");
-          } else if (titleLevel && titleLevel === 5) {
-            // h5 & h6
-            html = html.replace(/h3/gi, "h6");
-            html = html.replace(/h2/gi, "h5");
-          }
-
           return html.replace(/\bhref=/gi, 'rel="nofollow" href=');
         },
       }),

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -7,12 +7,26 @@ import { browser } from "$app/env";
 import { token } from "$lib/auth";
 import { defaultAcceptHeader } from "$lib/utils/api";
 
-export function markdownToHTML(md) {
+export function markdownToHTML(md, titleLevel) {
   const converter = new showdown.Converter({
     extensions: [
       () => ({
         type: "output",
         filter(html) {
+          if (titleLevel && titleLevel === 3) {
+            // h3 & h4
+            html = html.replace(/h3/gi, "h4");
+            html = html.replace(/h2/gi, "h3");
+          } else if (titleLevel && titleLevel === 4) {
+            // h4 & h5
+            html = html.replace(/h3/gi, "h5");
+            html = html.replace(/h2/gi, "h4");
+          } else if (titleLevel && titleLevel === 5) {
+            // h5 & h6
+            html = html.replace(/h3/gi, "h6");
+            html = html.replace(/h2/gi, "h5");
+          }
+
           return html.replace(/\bhref=/gi, 'rel="nofollow" href=');
         },
       }),

--- a/src/routes/structures/[slug]/_informations.svelte
+++ b/src/routes/structures/[slug]/_informations.svelte
@@ -25,7 +25,7 @@
 
   let fullDesc;
 
-  $: fullDesc = markdownToHTML(structure.fullDesc);
+  $: fullDesc = markdownToHTML(structure.fullDesc, 4);
   $: nationalLabelsDisplay = structure.nationalLabels
     .map((nationalLabel: string) => {
       return structuresOptions.nationalLabels.find(

--- a/tests/markdownToHTML.test.ts
+++ b/tests/markdownToHTML.test.ts
@@ -21,7 +21,7 @@ describe("markdownToHTML", () => {
   });
 
   test("bon niveau de titre", () => {
-    const text = `##titre1\n###titre2`;
+    const text = `#titre1\n##titre2`;
     expect(markdownToHTML(text)).toBe("<h2>titre1</h2>\n<h3>titre2</h3>");
     expect(markdownToHTML(text, 3)).toBe("<h3>titre1</h3>\n<h4>titre2</h4>");
     expect(markdownToHTML(text, 4)).toBe("<h4>titre1</h4>\n<h5>titre2</h5>");

--- a/tests/markdownToHTML.test.ts
+++ b/tests/markdownToHTML.test.ts
@@ -19,4 +19,12 @@ describe("markdownToHTML", () => {
     expect(markdownToHTML(text)).toBe(`<p>${text}</p>`);
     expect(markdownToHTML(text)).not.contains("nofollow");
   });
+
+  test("bon niveau de titre", () => {
+    const text = `##titre1\n###titre2`;
+    expect(markdownToHTML(text)).toBe("<h2>titre1</h2>\n<h3>titre2</h3>");
+    expect(markdownToHTML(text, 3)).toBe("<h3>titre1</h3>\n<h4>titre2</h4>");
+    expect(markdownToHTML(text, 4)).toBe("<h4>titre1</h4>\n<h5>titre2</h5>");
+    expect(markdownToHTML(text, 5)).toBe("<h5>titre1</h5>\n<h6>titre2</h6>");
+  });
 });

--- a/tests/markdownToHTML.test.ts
+++ b/tests/markdownToHTML.test.ts
@@ -10,7 +10,7 @@ describe("markdownToHTML", () => {
     const text = `[https://perdu.com/](Perdu) - [https://www.google.fr/](Google)`;
 
     expect(markdownToHTML(text)).toBe(
-      '<p><a rel="nofollow" href="Perdu">https://perdu.com/</a> - <a rel="nofollow" href="Google">https://www.google.fr/</a></p>'
+      '<p><a href="Perdu" rel="nofollow">https://perdu.com/</a> - <a href="Google" rel="nofollow">https://www.google.fr/</a></p>'
     );
   });
 


### PR DESCRIPTION
Pour permettre de créer une hiérarchie de titre cohérente sans être pertubé par le Wysiwyg :) 

https://www.notion.so/dora-beta/34b8d00134874128a1a2fa1e896ebe8b?v=983392aa02e64036b5d6ebc915a16f33