### PR TITLE
Arrete de revalider l'utilisateur à chaque changement de page

### DIFF
--- a/src/lib/auth.js
+++ b/src/lib/auth.js
@@ -84,7 +84,7 @@ export async function validateCredsAndFillUserInfo() {
   if (browser) {
     const lsToken = localStorage.getItem(tokenKey);
     if (lsToken) {
-      // Valide le token actuel et rempli les informations
+      // Valide le token actuel et remplit les informations
       // utilisateur
       try {
         const result = await getUserInfo(lsToken);

--- a/src/lib/auth.js
+++ b/src/lib/auth.js
@@ -84,7 +84,7 @@ export async function validateCredsAndFillUserInfo() {
   if (browser) {
     const lsToken = localStorage.getItem(tokenKey);
     if (lsToken) {
-      // Valide le token actuel, et rempli les informations
+      // Valide le token actuel et rempli les informations
       // utilisateur
       try {
         const result = await getUserInfo(lsToken);

--- a/src/routes/__layout.svelte
+++ b/src/routes/__layout.svelte
@@ -17,8 +17,11 @@
   }
 
   export async function load({ url }) {
-    await validateCredsAndFillUserInfo();
-    const currentUserInfo = get(userInfo);
+    let currentUserInfo = get(userInfo);
+    if (!currentUserInfo) {
+      await validateCredsAndFillUserInfo();
+      currentUserInfo = get(userInfo);
+    }
     if (
       currentUserInfo &&
       !(


### PR DESCRIPTION
Lors du passage à Inclusion Connect, le paramètre `url` a été rajouté à la fonction `load` du layout principal
https://github.com/betagouv/dora-front/commit/ac826906#diff-c3a76f211b02106e458d330c6c4dfb09844e51487170b2300cf76913360eda47R19

En conséquence, chaque changement d'url relançait le `load`, qui faisait une revalidation complète de l'utilisateur, via `validateCredsAndFillUserInfo`.

Les effets de bord étaient nombreux, par exemple à travers le composant EnsureLoggedIn, qui reconstruisait tous ses descendants au passage:
https://github.com/betagouv/dora-front/blob/main/src/lib/components/ensure-logged-in.svelte#L24

Solution: la validation n'est faite que si le store userInfo n'est pas encore initialisé, ce qui arrive lors du chargement initial, ou après logout.

Tickets affectés: 
- https://trello.com/c/Eu2OhFNJ
- https://trello.com/c/9o0qqd5V

