### PR TITLE
Corrige le rafraichissement des services lors du filtrage

### DIFF
--- a/src/lib/components/form/select/select-field.svelte
+++ b/src/lib/components/form/select/select-field.svelte
@@ -22,8 +22,10 @@
   export let display: "horizontal" | "vertical" = "horizontal";
   export let style: "common" | "filter" = "common";
   export let errorMessages: string[] | undefined = undefined;
-  export let handleEltChange: (d: { detail: string }) => void | undefined =
-    undefined;
+  export let onChange: (event: {
+    detail: string;
+    value: string | string[];
+  }) => void | undefined = undefined;
 
   let ariaDescribedBy = "";
 
@@ -95,7 +97,7 @@
       // As string
       value = newValue;
     }
-    if (handleEltChange) handleEltChange({ detail: name });
+    if (onChange) onChange({ detail: name, value });
     if (!isMultiple) toggleCombobox(false);
   }
 

--- a/src/lib/components/structures/form-wrapper.svelte
+++ b/src/lib/components/structures/form-wrapper.svelte
@@ -169,7 +169,7 @@
     placeholder="Choississez..."
     errorMessages={$formErrors.typology}
     bind:value={structure.typology}
-    {handleEltChange}
+    onChange={handleEltChange}
     choices={structuresOptions.typologies}
   />
 
@@ -321,7 +321,7 @@
     placeholder="Choississez..."
     errorMessages={$formErrors.nationalLabels}
     bind:value={structure.nationalLabels}
-    {handleEltChange}
+    onChange={handleEltChange}
     choices={structuresOptions.nationalLabels}
     isMultiple
   />

--- a/src/routes/structures/[slug]/index.svelte
+++ b/src/routes/structures/[slug]/index.svelte
@@ -42,7 +42,6 @@
   <hr class="mb-s24" />
   <ServicesList
     structure={$structure}
-    services={$structure.services}
     hasOptions={false}
     onRefresh={handleRefresh}
     total={$structure.services.length}

--- a/src/routes/structures/[slug]/services/_list.svelte
+++ b/src/routes/structures/[slug]/services/_list.svelte
@@ -22,7 +22,7 @@
   } from "$lib/types";
   import { computeUpdateStatusData } from "$lib/utils/service";
 
-  export let structure, services, total, servicesOptions;
+  export let structure, total, servicesOptions;
   export let hasOptions = true;
   export let onRefresh;
   export let limit;
@@ -95,7 +95,6 @@
     },
   ];
 
-  let servicesDisplayed;
   function sortService(se) {
     let sse = se.sort((a, b) => {
       let diff =
@@ -121,39 +120,44 @@
     return sse;
   }
 
-  $: canEdit = structure.isMember || $userInfo?.isStaff;
-  $: {
-    if (!selectedStatus && !selectedUpdateStatus) {
-      services = structure.services;
-    } else {
-      // By status
-      if (selectedStatus) {
-        if (selectedStatus === SERVICE_STATUSES.ARCHIVED)
-          services = structure.archivedServices;
-        else {
-          services = structure.services.filter(
-            (s) => s.status === selectedStatus
-          );
-        }
-      }
+  function handleEltChange(event) {
+    let services = structure.services;
+    if (event.detail === "update-status") {
+      selectedUpdateStatus = event.value;
+    }
+    if (event.detail === "status") {
+      selectedStatus = event.value;
+    }
 
-      // By update status
-      if (selectedUpdateStatus) {
-        services = services.filter(
-          (s) =>
-            computeUpdateStatusData(s).updateStatus === selectedUpdateStatus
+    if (selectedStatus) {
+      // By status
+      if (selectedStatus === SERVICE_STATUSES.ARCHIVED)
+        services = structure.archivedServices;
+      else {
+        services = structure.services.filter(
+          (s) => s.status === selectedStatus
         );
       }
     }
 
+    // By update status
+    if (selectedUpdateStatus) {
+      services = services.filter(
+        (s) => computeUpdateStatusData(s).updateStatus === selectedUpdateStatus
+      );
+    }
+
     servicesDisplayed = sortService(services);
   }
+
+  let servicesDisplayed = sortService(structure.services);
+  $: canEdit = structure.isMember || $userInfo?.isStaff;
 </script>
 
 <div class="mb-s24 md:flex md:items-center md:justify-between">
   <h2 class="text-france-blue">Services</h2>
   <div class="flex gap-s16">
-    {#if !!services.length && !hasOptions}
+    {#if !!servicesDisplayed.length && !hasOptions}
       <LinkButton
         label={`Voir tous les services (${total})`}
         to="/structures/{structure.slug}/services"
@@ -183,11 +187,12 @@
           label="Status"
           name="status"
           placeholder="Status"
-          bind:value={selectedStatus}
+          value={selectedStatus}
           choices={statusOptions}
           hideLabel
           style="filter"
           minDropdownWidth="min-w-[175px]"
+          onChange={handleEltChange}
         />
       </div>
       <div>
@@ -195,11 +200,12 @@
           label="Actualisation"
           name="update-status"
           placeholder="Actualisation"
-          bind:value={selectedUpdateStatus}
+          value={selectedUpdateStatus}
           choices={updateStatusOptions}
           hideLabel
           style="filter"
           minDropdownWidth="min-w-[265px]"
+          onChange={handleEltChange}
         />
       </div>
     </div>
@@ -239,8 +245,7 @@
         choices={serviceOrderOptions}
         hideLabel
         showIconForSelectedOption
-        handleEltChange={() =>
-          (servicesDisplayed = sortService(servicesDisplayed))}
+        onChange={() => (servicesDisplayed = sortService(servicesDisplayed))}
       />
     </div>
   </div>

--- a/src/routes/structures/[slug]/services/index.svelte
+++ b/src/routes/structures/[slug]/services/index.svelte
@@ -30,7 +30,6 @@
 </svelte:head>
 
 <List
-  services={$structure.services || []}
   {servicesOptions}
   structure={$structure}
   total={$structure.services.length}


### PR DESCRIPTION
https://trello.com/c/hXvZRv1f

Lors du passage d'un filtre à l'autre, on ne repartait pas de l'ensemble de la liste des services, mais de la liste filtrée.

Ça aurait pu être corrigé plus simplement, mais j'en ai profité pour corriger deux sources de confusion:

- dans le composant _list.svelte, on passait à la fois la structure et la liste des services
```
<List
  services={$structure.services || []}
  structure={$structure}
  ...
/>
```
Mais une fois dans le composant, on utilisait `structure.services` pour se réferrer à la liste non filtrée, et on écrasait `services` avec la liste filtrée.
Je ne passe maintenant plus que la structure, et on utilise toujours explicitement structure.services dans le composant.

- la réactivité était un peu extrême -- j'ai préféré passer par un handler pour mieux définir l'évolution des états.