### PR TITLE
Ne force plus l'affichage des villes en majuscule

### DIFF
--- a/src/routes/favoris/bookmark-card.svelte
+++ b/src/routes/favoris/bookmark-card.svelte
@@ -15,7 +15,7 @@
         <a href="/structures/{service.structure}" class="block text-f14">
           {bookmark.service.structureInfo.name}
           {#if service.postalCode}<span
-              class="legend ml-s8 font-bold uppercase text-gray-dark"
+              class="legend ml-s8 font-bold text-gray-dark"
               >{service.postalCode} {service.city}</span
             >{/if}
         </a>

--- a/src/routes/recherche/search-result.svelte
+++ b/src/routes/recherche/search-result.svelte
@@ -16,7 +16,7 @@
         <div class="text-f14">
           {result.structureInfo.name}
           {#if result.location && result.location !== "À distance"}<span
-              class="legend ml-s8 font-bold uppercase text-gray-dark"
+              class="legend ml-s8 font-bold text-gray-dark"
               >{result.location}</span
             >{/if}
         </div>


### PR DESCRIPTION
https://trello.com/c/iIAkmSqL/70-am%C3%A9liorer-la-capitalisation-des-noms-de-ville