### PR TITLE
Corrections du comportement des formulaires NPS

### DIFF
--- a/src/lib/components/specialized/tally-nps-popup.svelte
+++ b/src/lib/components/specialized/tally-nps-popup.svelte
@@ -10,6 +10,7 @@
   import { onDestroy, onMount } from "svelte";
 
   export let formId: TallyFormId;
+  export let keySuffix = "";
   export let timeoutSeconds;
   export let hiddenFields: Partial<HiddenFields> = {};
 
@@ -17,10 +18,10 @@
 
   onMount(() => {
     if (window.Tally) {
-      window.Tally.closePopup(formId);
+      window.Tally.closePopup(formId, keySuffix);
     }
 
-    if (canDisplayNpsForm(formId)) {
+    if (canDisplayNpsForm(formId, keySuffix)) {
       timeoutFn = setTimeout(() => {
         if (window.Tally) {
           window.Tally.openPopup(formId, {
@@ -29,10 +30,10 @@
             hideTitle: true,
             hiddenFields,
             onClose: () => {
-              saveNpsFormDateClosed(formId);
+              saveNpsFormDateClosed(formId, keySuffix);
             },
             onSubmit: () => {
-              saveNpsFormDateClosed(formId);
+              saveNpsFormDateClosed(formId, keySuffix);
             },
           });
         }

--- a/src/lib/components/specialized/tally-nps-popup.svelte
+++ b/src/lib/components/specialized/tally-nps-popup.svelte
@@ -16,6 +16,9 @@
 
   let timeoutFn: ReturnType<typeof setTimeout>;
 
+  // Pour différencier un formulaire fermé par l'utilsateur vs un changement de page
+  let tallyFormClosedByNavigation = false;
+
   onMount(() => {
     if (window.Tally) {
       window.Tally.closePopup(formId, keySuffix);
@@ -30,7 +33,10 @@
             hideTitle: true,
             hiddenFields,
             onClose: () => {
-              saveNpsFormDateClosed(formId, keySuffix);
+              if (!tallyFormClosedByNavigation) {
+                saveNpsFormDateClosed(formId, keySuffix);
+              }
+              tallyFormClosedByNavigation = false;
             },
             onSubmit: () => {
               saveNpsFormDateClosed(formId, keySuffix);
@@ -43,6 +49,7 @@
 
   onDestroy(() => {
     if (browser && window.Tally) {
+      tallyFormClosedByNavigation = true;
       window.Tally.closePopup(formId);
     }
 

--- a/src/lib/components/specialized/tally-nps-popup.svelte
+++ b/src/lib/components/specialized/tally-nps-popup.svelte
@@ -16,7 +16,7 @@
 
   let timeoutFn: ReturnType<typeof setTimeout>;
 
-  // Pour différencier un formulaire fermé par l'utilsateur vs un changement de page
+  // Pour différencier un formulaire fermé par l'utilisateur vs un changement de page
   let tallyFormClosedByNavigation = false;
 
   onMount(() => {

--- a/src/lib/utils/nps.ts
+++ b/src/lib/utils/nps.ts
@@ -18,20 +18,34 @@ interface TallyFormLocalStorageItem {
   lastSubmitted: string;
 }
 
-function getNpsAnswerLocalStorageKey(formId: TallyFormId): string {
-  return `tallyForm-${formId}`;
+function getNpsAnswerLocalStorageKey(
+  formId: TallyFormId,
+  keySuffix: string
+): string {
+  let key = `tallyForm-${formId}`;
+  if (keySuffix) {
+    key = `${key}-${keySuffix}`;
+  }
+
+  return key;
 }
 
-export function saveNpsFormDateClosed(formId: TallyFormId): void {
-  const key = getNpsAnswerLocalStorageKey(formId);
+export function saveNpsFormDateClosed(
+  formId: TallyFormId,
+  keySuffix: string
+): void {
+  const key = getNpsAnswerLocalStorageKey(formId, keySuffix);
   const item: TallyFormLocalStorageItem = {
     lastSubmitted: dayjs().toString(),
   };
   localStorage.setItem(key, JSON.stringify(item));
 }
 
-export function canDisplayNpsForm(formId: TallyFormId): boolean {
-  const key = getNpsAnswerLocalStorageKey(formId);
+export function canDisplayNpsForm(
+  formId: TallyFormId,
+  keySuffix: string
+): boolean {
+  const key = getNpsAnswerLocalStorageKey(formId, keySuffix);
   const item = JSON.parse(localStorage.getItem(key));
   if (item && "lastSubmitted" in item) {
     const lastSubmitted = dayjs(item.lastSubmitted);

--- a/src/routes/recherche/+page.svelte
+++ b/src/routes/recherche/+page.svelte
@@ -157,6 +157,7 @@
 
 <TallyNpsPopup
   formId={TallyFormId.NPS_FORM_ID}
+  keySuffix="chercheur"
   timeoutSeconds={45}
   hiddenFields={{ user: "chercheur" }}
 />

--- a/src/routes/services/[slug]/+page.svelte
+++ b/src/routes/services/[slug]/+page.svelte
@@ -109,6 +109,7 @@
       {:else if structureHasPublishedServices}
         <TallyNpsPopup
           formId={TallyFormId.NPS_FORM_ID}
+          keySuffix="offreur"
           timeoutSeconds={30}
           hiddenFields={{ user: "offreur" }}
         />
@@ -116,6 +117,7 @@
     {:else}
       <TallyNpsPopup
         formId={TallyFormId.NPS_FORM_ID}
+        keySuffix="chercheur"
         timeoutSeconds={45}
         hiddenFields={{ user: "chercheur" }}
       />

--- a/src/routes/structures/[slug]/+layout.svelte
+++ b/src/routes/structures/[slug]/+layout.svelte
@@ -37,6 +37,7 @@
   <TallyNpsPopup
     formId={TallyFormId.NPS_FORM_ID}
     timeoutSeconds={30}
+    keySuffix="offreur"
     hiddenFields={{ user: "offreur" }}
   />
 {/if}


### PR DESCRIPTION
https://trello.com/c/EgvZNnPk/350-ajustement-des-nps-pour-le-gip

Deux soucis :
- le formId n'est plus suffisant pour différencier le NPS
- la fermeture à cause d'une navigation vs clic sur le bouton close appelaient `onClose` dans tous les cas...