### PR TITLE
Amélioration responsive sur la page structures

### DIFF
--- a/src/routes/structures/[slug]/collaborateurs/member.svelte
+++ b/src/routes/structures/[slug]/collaborateurs/member.svelte
@@ -9,7 +9,7 @@
 </script>
 
 <div
-  class="flex items-center gap-s16 rounded-md border border-gray-01 py-s16 px-s24"
+  class="flex flex-wrap items-center gap-s16 rounded-md border border-gray-01 py-s16 px-s24"
   class:bg-gray-01={isMyself}
 >
   <div class="flex flex-col">

--- a/src/routes/structures/[slug]/modeles/list.svelte
+++ b/src/routes/structures/[slug]/modeles/list.svelte
@@ -56,7 +56,7 @@
     <h2 class="mb-s0 text-france-blue">Modèles</h2>
     {#if limit}<Count>{total}</Count>{/if}
   </div>
-  <div class="flex gap-s16">
+  <div class="flex flex-wrap gap-s16">
     {#if !!models.length && !hasOptions}
       <LinkButton
         label="Voir tous les modèles"

--- a/src/routes/structures/[slug]/services/list.svelte
+++ b/src/routes/structures/[slug]/services/list.svelte
@@ -204,7 +204,7 @@
     <h2 class="mb-s0 text-france-blue">Services</h2>
     {#if limit}<Count>{total}</Count>{/if}
   </div>
-  <div class="flex gap-s16">
+  <div class="flex flex-wrap gap-s16">
     {#if !!servicesDisplayed.length && !hasOptions}
       <LinkButton
         label="Voir tous les services"


### PR DESCRIPTION
Nouveaux soucis de responsive lié à (pour les écrans < 450px de large) :
https://trello.com/c/I3avcuJV/233-version-mobile-de-la-fiche-struture-revoir-les-onglets-de-navigation-scroll-horizontal