### PR TITLE
Corrige la synchronisation des descriptions lors de l'instanciation d'un modèle

### DIFF
--- a/src/lib/components/specialized/services/field-model.svelte
+++ b/src/lib/components/specialized/services/field-model.svelte
@@ -23,9 +23,7 @@
     // tiptap insère des caractères en fin de chaine.
     // on les supprime pour faire la comparaison
     if (type === "markdown") {
-      const trimmedVal2 = val2.replace(/\n\n$/u, "");
-
-      return val1 === trimmedVal2;
+      return val1.trim() === val2.trim();
     }
 
     return val1 === val2;
@@ -76,7 +74,7 @@
               {/each}
             </div>
           {:else if type === "markdown"}
-            {@html markdownToHTML(value)}
+            {@html markdownToHTML(value, 2)}
           {:else if type === "boolean"}
             <p class="mb-s0 text-f14">{value === true ? "Oui" : "Non"}</p>
           {:else if type === "text"}

--- a/src/lib/utils/misc.ts
+++ b/src/lib/utils/misc.ts
@@ -16,7 +16,10 @@ const INSANE_CONFIGURATION = {
   },
 };
 
-export function markdownToHTML(markdownContent: string, titleLevel = 2) {
+export function markdownToHTML(
+  markdownContent: string,
+  titleLevel: number | undefined = undefined
+) {
   const converter = new showdown.Converter({
     headerLevelStart: titleLevel,
     tables: true,

--- a/src/routes/admin/contributions/suggestion-modal.svelte
+++ b/src/routes/admin/contributions/suggestion-modal.svelte
@@ -38,11 +38,11 @@
 
         <Line
           label="Descriptif complet du service"
-          data={markdownToHTML(suggestion.serviceInfo.fullDesc)}
+          data={markdownToHTML(suggestion.serviceInfo.fullDesc, 2)}
           verticalLayout
         >
           <div class="m-s16 border-l-8 border-gray-02 pl-s16">
-            {@html markdownToHTML(suggestion.serviceInfo.fullDesc)}
+            {@html markdownToHTML(suggestion.serviceInfo.fullDesc, 2)}
           </div>
         </Line>
 

--- a/src/routes/admin/services/[slug]/+page.svelte
+++ b/src/routes/admin/services/[slug]/+page.svelte
@@ -18,7 +18,7 @@
   export let data: PageData;
 
   const structure = data.service.structure;
-  const description = markdownToHTML(data.service.fullDesc);
+  const description = markdownToHTML(data.service.fullDesc, 2);
 
   async function handleRefresh() {
     data.service = await getServiceAdmin(data.service.slug);

--- a/src/routes/admin/structures/[slug]/+page.svelte
+++ b/src/routes/admin/structures/[slug]/+page.svelte
@@ -15,7 +15,7 @@
 
   export let data: PageData;
 
-  const description = markdownToHTML(data.structure.fullDesc);
+  const description = markdownToHTML(data.structure.fullDesc, 2);
 
   async function handleRefresh() {
     data.structure = await getStructureAdmin(data.structure.slug);

--- a/src/tests/markdownToHTML.test.ts
+++ b/src/tests/markdownToHTML.test.ts
@@ -23,7 +23,9 @@ describe("markdownToHTML", () => {
 
   test("bon niveau de titre", () => {
     const text = `#titre1\n##titre2`;
-    expect(markdownToHTML(text)).toBe("<h2>titre1</h2>\n<h3>titre2</h3>");
+    expect(markdownToHTML(text)).toBe("<h1>titre1</h1>\n<h2>titre2</h2>");
+    expect(markdownToHTML(text, 1)).toBe("<h1>titre1</h1>\n<h2>titre2</h2>");
+    expect(markdownToHTML(text, 2)).toBe("<h2>titre1</h2>\n<h3>titre2</h3>");
     expect(markdownToHTML(text, 3)).toBe("<h3>titre1</h3>\n<h4>titre2</h4>");
     expect(markdownToHTML(text, 4)).toBe("<h4>titre1</h4>\n<h5>titre2</h5>");
     expect(markdownToHTML(text, 5)).toBe("<h5>titre1</h5>\n<h6>titre2</h6>");


### PR DESCRIPTION
https://trello.com/c/Y4d3Qea2

Quand la description longue d'un modèle contenait au moins un titre, lors de l'instanciation du modèle, la description etait marquée comme modifiée.
Le problème avait lieu dans editor.svelte: le passage par markdownToHTML mettait un niveau de titre minimal à 2 (valeur par défaut de l'argument), et faussait donc la comparaison.

Solution adoptée:
- on enlève la valeur par défaut de `markdownToHTML`; il s'agit d'une mutation qui ne doit etre faite qu'à l'affichage
https://github.com/betagouv/dora-front/pull/219/files#diff-1dd60574449dd8540b7c5eaf7ce59d3fe19835e0e4d1def9cdf6bc5de77c4305R19
- on applique cette valeur coté appelant, chaque fois ou ce n'était pas le cas et où c'est pertinent.