### PR TITLE
Retrait de `inline:"@sveltejs/kit"` pour les tests front

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -12,7 +12,6 @@ export default defineConfig(({ mode }) => {
     },
 
     test: {
-      deps: { inline: ["@sveltejs/kit"] },
       include: ["src/**/*.{test,spec}.{js,ts}"],
     },
   };


### PR DESCRIPTION
J'ai juste fait un `npm i` et c'était bon 🙂
Du coup, je pense que c'était juste des `node_modules` pas à jour...

https://trello.com/c/75Y65Z31/619-correction-vitest