### PR TITLE
Fix old browser errors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "eslint": "^8.36.0",
         "eslint-config-prettier": "^8.7.0",
         "eslint-plugin-svelte3": "^4.0.0",
+        "hexoid": "^1.0.0",
         "husky": "^8.0.3",
         "iframe-resizer": "^4.3.6",
         "insane": "^2.6.2",
@@ -3237,6 +3238,15 @@
       "license": "MIT",
       "bin": {
         "he": "bin/he"
+      }
+    },
+    "node_modules/hexoid": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/hexoid/-/hexoid-1.0.0.tgz",
+      "integrity": "sha512-QFLV0taWQOZtvIRIAdBChesmogZrtuXvVWsFHZTk2SU+anspqZ2vMnoLg7IE1+Uk16N19APic1BuF8bC8c2m5g==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/human-signals": {
@@ -8378,6 +8388,12 @@
     },
     "he": {
       "version": "0.5.0",
+      "dev": true
+    },
+    "hexoid": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/hexoid/-/hexoid-1.0.0.tgz",
+      "integrity": "sha512-QFLV0taWQOZtvIRIAdBChesmogZrtuXvVWsFHZTk2SU+anspqZ2vMnoLg7IE1+Uk16N19APic1BuF8bC8c2m5g==",
       "dev": true
     },
     "human-signals": {

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "eslint": "^8.36.0",
     "eslint-config-prettier": "^8.7.0",
     "eslint-plugin-svelte3": "^4.0.0",
+    "hexoid": "^1.0.0",
     "husky": "^8.0.3",
     "iframe-resizer": "^4.3.6",
     "insane": "^2.6.2",

--- a/src/lib/components/display/accordion.svelte
+++ b/src/lib/components/display/accordion.svelte
@@ -1,10 +1,11 @@
 <script lang="ts">
   import { arrowDownSIcon, arrowUpSIcon } from "$lib/icons";
+  import { randomId } from "$lib/utils/random";
 
   export let title: string;
   export let expanded = true;
 
-  const id = crypto.randomUUID();
+  const id = randomId();
 </script>
 
 <h2 class="mb-s40">

--- a/src/lib/components/display/button-menu.svelte
+++ b/src/lib/components/display/button-menu.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import Button from "$lib/components/display/button.svelte";
   import { clickOutside } from "$lib/utils/misc";
+  import { randomId } from "$lib/utils/random";
 
   export let icon: string | undefined = undefined;
   export let label: string | undefined = undefined;
@@ -9,7 +10,7 @@
   export let small = false;
 
   let isOpen = false;
-  const id = `button-menu-${crypto.randomUUID()}`;
+  const id = `button-menu-${randomId()}`;
 
   function handleClickOutside(_event) {
     isOpen = false;

--- a/src/lib/components/inputs/obsolete/select-field.svelte
+++ b/src/lib/components/inputs/obsolete/select-field.svelte
@@ -8,6 +8,7 @@
     getChoicesFromKey,
   } from "$lib/utils/choice";
   import { clickOutside } from "$lib/utils/misc";
+  import { randomId } from "$lib/utils/random";
   import { tick } from "svelte";
   import SelectLabel from "./select-label.svelte";
   import SelectOptions from "./select-options.svelte";
@@ -40,7 +41,7 @@
   let filterText = "";
 
   // *** Accessibilité
-  const uuid: string = crypto.randomUUID(); // Pour éviter les conflits d'id si le composant est présent plusieurs fois sur la page
+  const uuid: string = randomId(); // Pour éviter les conflits d'id si le composant est présent plusieurs fois sur la page
   let expanded = false;
 
   // Gestion de l'outline avec la navigation au clavier

--- a/src/lib/components/specialized/services/fields-address.svelte
+++ b/src/lib/components/specialized/services/fields-address.svelte
@@ -6,11 +6,12 @@
   import HiddenField from "$lib/components/forms/fields/hidden-field.svelte";
   import { syncIcon } from "$lib/icons";
   import type { GeoApiValue, Service, Structure } from "$lib/types";
+  import { randomId } from "$lib/utils/random";
 
   export let entity: Service | Structure;
   export let parent: Structure | null = null;
 
-  let key = crypto.randomUUID();
+  let key = randomId();
 
   function handleAddressChange(address) {
     const props = address?.properties;
@@ -43,7 +44,7 @@
       entity.longitude = longitude;
 
       // force la mise à jour du bloc adresse
-      key = crypto.randomUUID();
+      key = randomId();
     }
   }
 

--- a/src/lib/components/specialized/services/service-state-update-select.svelte
+++ b/src/lib/components/specialized/services/service-state-update-select.svelte
@@ -21,6 +21,7 @@
   } from "$lib/requests/services";
   import type { Service, ServiceStatus, ShortService } from "$lib/types";
   import { clickOutside } from "$lib/utils/misc";
+  import { randomId } from "$lib/utils/random";
   import { getAvailableOptionsForStatus } from "$lib/utils/service";
   import { serviceSchema } from "$lib/validation/schemas/service";
   import { validate } from "$lib/validation/validation";
@@ -74,7 +75,7 @@
   export let fullWidth = false;
 
   // *** Accessibilité
-  const uuid: string = crypto.randomUUID(); // Pour éviter les conflits d'id si le composant est présent plusieurs fois sur la page
+  const uuid: string = randomId(); // Pour éviter les conflits d'id si le composant est présent plusieurs fois sur la page
   let isDropdownOpen = false;
 
   // Gestion de l'outline avec la navigation au clavier

--- a/src/lib/utils/random.ts
+++ b/src/lib/utils/random.ts
@@ -1,0 +1,7 @@
+import hexoid from "hexoid";
+
+const generateId = hexoid();
+
+export function randomId(): string {
+  return generateId();
+}

--- a/src/lib/validation/validation.ts
+++ b/src/lib/validation/validation.ts
@@ -145,7 +145,7 @@ export function validate(
       checkRequired
     );
 
-    isValid &&= valid;
+    isValid = isValid && valid;
     validatedData[fieldName] = value;
 
     if (!valid) {
@@ -181,7 +181,7 @@ export function validate(
           checkRequired
         );
 
-        isValid &&= depValid;
+        isValid = isValid && depValid;
         validatedData[depName] = depValue;
         if (!depValid) {
           errorFields.push(fullFormSchema[depName].name);


### PR DESCRIPTION
En supprimant les usages à `crypto.randomUUID` et `&&=` (ce qui a un impact limité niveau code), on obtient un premier niveau d'amélioration de la rétro-compatibilité :
- `Firefox 95 (décembre 2021)` => `Firefox 74 (mars 2020)`
- `Chrome 92 (juilllet 2021)` => `Chrome 85 (février 2020)`

https://trello.com/c/8l6pVCph/662-des-utilisateurs-avec-une-vieille-version-de-firefox-ou-chrome-ne-peuvent-pas-se-connecter

On peut aller plus loin (retrait de `?.` et `??`) mais ça sera plus lourd…