### PR TITLE
Mis à jour de sync_checksum via la modale d'actualisation

### DIFF
--- a/src/lib/components/specialized/services/set-as-updated-modal.svelte
+++ b/src/lib/components/specialized/services/set-as-updated-modal.svelte
@@ -15,7 +15,7 @@
 
   async function setAsUpdated() {
     // TODO: il serait sans doute mieux d'avoir un endpoint dédié.
-    await createOrModifyService(service);
+    await createOrModifyService({ ...service, markSynced: true });
     isOpen = false;
     await onRefresh();
   }


### PR DESCRIPTION
(https://trello.com/c/pvpBj1pD/798-modelchanged-doit-prendre-en-compte-les-dates-de-modification-du-service-et-du-mod%C3%A8le)

Il s'avère que la mise à jour via la modale mettait à jour la date de modification sans mettre à jour le `sync_checksum`