### PR TITLE
Correction d'un faux message d'erreur sur "Autres labels"

### DIFF
--- a/src/lib/requests/structures.ts
+++ b/src/lib/requests/structures.ts
@@ -25,7 +25,7 @@ function structureToBack(structure: Structure) {
 
 function structureToFront(structure: Structure): Structure {
   const result = { ...structure };
-  if (structure.otherLabels.length) {
+  if (Array.isArray(structure.otherLabels)) {
     result.otherLabels = structure.otherLabels.join(", ");
   }
   return result;


### PR DESCRIPTION
https://trello.com/c/sdjBE8z0/812-probl%C3%A8me-validation-autre-label

Cause :
En back, on a un tableau et une chaîne de caractère en front…
La conversion était bien faite mais on ne gérait pas le tableau vide… et la condition `isString()` du formulaire échouait car on avait un tableau`[]`