### PR TITLE
Corrections des premiers retours/bugs sur l'orientation

### DIFF
--- a/src/lib/components/hoc/modal.svelte
+++ b/src/lib/components/hoc/modal.svelte
@@ -10,6 +10,7 @@
   export let overflow = false;
   export let title: string | undefined = undefined;
   export let subtitle: string | undefined = undefined;
+  export let hideTitle = false;
   export let width: "small" | "medium" | undefined = undefined;
   export let targetId: string | undefined = undefined;
   export let canClose = true;
@@ -98,9 +99,9 @@
         class:overflow-y-auto={overflow}
         on:click|stopPropagation
       >
-        <div class="mb-s24">
+        <div class:mb-s24={!hideTitle} class:float-right={hideTitle}>
           <div class="flex justify-between">
-            {#if title}
+            {#if title && !hideTitle}
               <h1
                 class="text-f22 leading-32 text-france-blue md:text-f24 lg:text-f28 lg:leading-40 xl:text-f32"
               >
@@ -120,17 +121,19 @@
               </div>
             {/if}
           </div>
-          {#if subtitle}
+          {#if subtitle && !hideTitle}
             <div>
               <p class="text-f14 text-gray-text">{subtitle}</p>
             </div>
           {/if}
-          {#if $$slots.subtitle}
+          {#if $$slots.subtitle && !hideTitle}
             <div class="text-f14 text-gray-text">
               <slot name="subtitle" />
             </div>
           {/if}
-          <hr class="-mx-s24 my-s24" />
+          {#if !hideTitle}
+            <hr class="-mx-s24 my-s24" />
+          {/if}
         </div>
 
         <div class="body max-h-s512 overflow-auto">

--- a/src/lib/components/inputs/uploader.svelte
+++ b/src/lib/components/inputs/uploader.svelte
@@ -75,7 +75,7 @@
       on:change={handleSubmit}
       {disabled}
       type="file"
-      accept=".doc, .docx, .pdf, .png, .jpeg, .jpg, .odt"
+      accept=".doc, .docx, .pdf, .png, .jpeg, .jpg, .odt, .xls, .xlsx, .ods"
       multiple
       class="font-bold file:rounded file:border file:border-magenta-cta file:bg-white file:px-s8 file:py-s6 file:text-f14 file:leading-normal file:text-magenta-cta file:hover:border-magenta-hover file:hover:bg-magenta-hover file:hover:!text-white file:active:border-france-blue file:active:text-france-blue file:disabled:border-gray-01 file:disabled:disabled:text-gray-text-alt2 file:lg:px-s10"
     />{progress != null ? `${Math.round(progress)} %` : ""}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -544,6 +544,10 @@ export type DayPeriod = "timeSlot1" | "timeSlot2";
 type ContactPreferences = "TELEPHONE" | "EMAIL" | "AUTRE";
 
 export interface Orientation {
+  // Tous les champs de l'étape 1 pouvant être optionnels
+  // on est contraint de se baser sur un booléen pour s'assurer que l'étape 1 a bien été visitée
+  firstStepView: boolean;
+
   situation: string[];
   situationOther: string;
   requirements: string[];

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -546,7 +546,7 @@ type ContactPreferences = "TELEPHONE" | "EMAIL" | "AUTRE";
 export interface Orientation {
   // Tous les champs de l'étape 1 pouvant être optionnels
   // on est contraint de se baser sur un booléen pour s'assurer que l'étape 1 a bien été visionnée
-  firstStepView: boolean;
+  firstStepDone: boolean;
 
   situation: string[];
   situationOther: string;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -545,7 +545,7 @@ type ContactPreferences = "TELEPHONE" | "EMAIL" | "AUTRE";
 
 export interface Orientation {
   // Tous les champs de l'étape 1 pouvant être optionnels
-  // on est contraint de se baser sur un booléen pour s'assurer que l'étape 1 a bien été visitée
+  // on est contraint de se baser sur un booléen pour s'assurer que l'étape 1 a bien été visionnée
   firstStepView: boolean;
 
   situation: string[];

--- a/src/lib/utils/file.ts
+++ b/src/lib/utils/file.ts
@@ -1,3 +1,13 @@
-export function extractFileName(path: string) {
-  return path.split("/").pop();
+export function formatFilePath(filePath: string): string {
+  const file = filePath.split("/").pop() as string;
+
+  const dotPosition = file.lastIndexOf(".");
+  if (dotPosition === -1) {
+    return file;
+  }
+
+  const name = file.slice(0, dotPosition);
+  const extension = file.slice(file.lastIndexOf("."), file.length);
+
+  return `${name} (${extension})`;
 }

--- a/src/lib/utils/file.ts
+++ b/src/lib/utils/file.ts
@@ -1,0 +1,3 @@
+export function extractFileName(path: string) {
+  return path.split("/").pop();
+}

--- a/src/lib/utils/service.ts
+++ b/src/lib/utils/service.ts
@@ -118,20 +118,6 @@ export function getSubCategoryLabel(
   return subCategory?.label ?? "";
 }
 
-export function formatFilePath(filePath: string) {
-  const file = filePath.split("/").pop();
-
-  const dotPosition = file.lastIndexOf(".");
-  if (dotPosition === -1) {
-    return file;
-  }
-
-  const name = file.slice(0, dotPosition);
-  const extension = file.slice(file.lastIndexOf("."), file.length);
-
-  return `${name} (${extension})`;
-}
-
 export function isNotFreeService(feeConditionValue: FeeCondition): boolean {
   return feeConditionValue !== "gratuit";
 }

--- a/src/routes/(modeles-services)/_common/display/service-mobilisation.svelte
+++ b/src/routes/(modeles-services)/_common/display/service-mobilisation.svelte
@@ -6,10 +6,6 @@
   import { trackMobilisation } from "$lib/utils/plausible";
   import LinkButton from "$lib/components/display/link-button.svelte";
   import { token } from "$lib/utils/auth";
-  import {
-    initEmptyOrientation,
-    orientation,
-  } from "../../services/[slug]/orienter/store";
 
   export let service;
   let contactOpen = false;
@@ -59,7 +55,6 @@
           <LinkButton
             nofollow
             to="/services/{service.slug}/orienter"
-            on:click={() => ($orientation = initEmptyOrientation())}
             extraClass={backgroundColor === "blue"
               ? "bg-white !text-france-blue hover:!text-white text-center !whitespace-normal text-center"
               : "!whitespace-normal text-center"}

--- a/src/routes/(modeles-services)/_common/display/service-mobilisation.svelte
+++ b/src/routes/(modeles-services)/_common/display/service-mobilisation.svelte
@@ -6,6 +6,10 @@
   import { trackMobilisation } from "$lib/utils/plausible";
   import LinkButton from "$lib/components/display/link-button.svelte";
   import { token } from "$lib/utils/auth";
+  import {
+    initEmptyOrientation,
+    orientation,
+  } from "../../services/[slug]/orienter/store";
 
   export let service;
   let contactOpen = false;
@@ -55,6 +59,7 @@
           <LinkButton
             nofollow
             to="/services/{service.slug}/orienter"
+            on:click={() => ($orientation = initEmptyOrientation())}
             extraClass={backgroundColor === "blue"
               ? "bg-white !text-france-blue hover:!text-white text-center !whitespace-normal text-center"
               : "!whitespace-normal text-center"}

--- a/src/routes/(modeles-services)/_common/display/service-mobilize.svelte
+++ b/src/routes/(modeles-services)/_common/display/service-mobilize.svelte
@@ -2,7 +2,7 @@
   import Accordion from "$lib/components/display/accordion.svelte";
   import type { Service } from "$lib/types";
   import { addlinkToUrls } from "$lib/utils/misc";
-  import { formatFilePath } from "$lib/utils/service";
+  import { formatFilePath } from "$lib/utils/file";
 
   export let service: Service;
 </script>

--- a/src/routes/(modeles-services)/services/[slug]/orienter/+page.svelte
+++ b/src/routes/(modeles-services)/services/[slug]/orienter/+page.svelte
@@ -56,7 +56,7 @@
     </p>
     <hr class="my-s40" />
     <p class="mb-s40 max-w-2xl text-f18">
-      Avant de commencer la procédure, vérifiez l‘éligibilité du ou de la
+      Avant de commencer la procédure, vérifiez l’éligibilité du ou de la
       bénéficiaire et consultez la liste des documents requis.
     </p>
 

--- a/src/routes/(modeles-services)/services/[slug]/orienter/+page.svelte
+++ b/src/routes/(modeles-services)/services/[slug]/orienter/+page.svelte
@@ -20,7 +20,7 @@
   let requesting = false;
 
   onMount(() => {
-    $orientation.firstStepView = true;
+    $orientation.firstStepDone = true;
   });
 
   function handleChange(validatedData) {

--- a/src/routes/(modeles-services)/services/[slug]/orienter/+page.svelte
+++ b/src/routes/(modeles-services)/services/[slug]/orienter/+page.svelte
@@ -11,12 +11,17 @@
   import { orientationStep1Schema } from "./schema";
   import { goto } from "$app/navigation";
   import { arrowLeftLineIcon } from "$lib/icons";
+  import { onMount } from "svelte";
 
   export let data;
 
   const { service, servicesOptions } = data;
 
   let requesting = false;
+
+  onMount(() => {
+    $orientation.firstStepView = true;
+  });
 
   function handleChange(validatedData) {
     $orientation = { ...validatedData };

--- a/src/routes/(modeles-services)/services/[slug]/orienter/contact-box.svelte
+++ b/src/routes/(modeles-services)/services/[slug]/orienter/contact-box.svelte
@@ -17,7 +17,10 @@
         <strong>{service.contactName}</strong>
       </p>
     {/if}
-    <ContactPhone {service} />
+
+    {#if service.contactPhone}
+      <ContactPhone {service} />
+    {/if}
     <ContactEmail {service} />
   </div>
 </div>

--- a/src/routes/(modeles-services)/services/[slug]/orienter/demande/+page.svelte
+++ b/src/routes/(modeles-services)/services/[slug]/orienter/demande/+page.svelte
@@ -16,12 +16,20 @@
   import Form from "$lib/components/forms/form.svelte";
   import { goto } from "$app/navigation";
   import { arrowLeftLineIcon } from "$lib/icons";
+  import { onMount } from "svelte";
 
   export let data: PageData;
 
   const { service, servicesOptions } = data;
 
   let requesting = false;
+
+  onMount(() => {
+    // On redirige vers l'étape 1 si l'utilisateur n'a pas passé l'étape 1
+    if ($orientation.situation.length === 0) {
+      goto(`/services/${data.service.slug}/orienter`);
+    }
+  });
 
   function handleChange(validatedData) {
     $orientation = { ...validatedData };

--- a/src/routes/(modeles-services)/services/[slug]/orienter/demande/+page.svelte
+++ b/src/routes/(modeles-services)/services/[slug]/orienter/demande/+page.svelte
@@ -132,12 +132,7 @@
     </p>
 
     <div class="mt-s40 flex flex-row justify-between gap-x-s24">
-      <OrientationForm
-        {attachmentsInvalid}
-        {credentials}
-        {service}
-        {servicesOptions}
-      />
+      <OrientationForm {attachmentsInvalid} {credentials} {service} />
       <div class="mb-s32 w-full shrink-0 md:w-[384px]">
         <ContactBox {service} />
       </div>

--- a/src/routes/(modeles-services)/services/[slug]/orienter/demande/+page.svelte
+++ b/src/routes/(modeles-services)/services/[slug]/orienter/demande/+page.svelte
@@ -25,8 +25,7 @@
   let requesting = false;
 
   onMount(() => {
-    // On redirige vers l'étape 1 si l'utilisateur n'a pas passé l'étape 1
-    if ($orientation.situation.length === 0) {
+    if (!$orientation.firstStepView) {
       goto(`/services/${data.service.slug}/orienter`);
     }
   });

--- a/src/routes/(modeles-services)/services/[slug]/orienter/demande/+page.svelte
+++ b/src/routes/(modeles-services)/services/[slug]/orienter/demande/+page.svelte
@@ -124,7 +124,7 @@
     <hr class="my-s40" />
     <p class="mb-s40 max-w-2xl text-f18">
       Ce formulaire collecte les informations nécessaires pour la demande
-      d‘orientation. Veuillez fournir tous les éléments demandés.
+      d’orientation. Veuillez fournir tous les éléments demandés.
     </p>
     <p>
       Vous recevrez une copie de cette demande, tout comme le ou la
@@ -156,7 +156,7 @@
       id="publish"
       type="submit"
       disabled={requesting}
-      label="Envoyer l‘orientation"
+      label="Envoyer l’orientation"
     />
   </StickyFormSubmissionRow>
 </Form>

--- a/src/routes/(modeles-services)/services/[slug]/orienter/demande/+page.svelte
+++ b/src/routes/(modeles-services)/services/[slug]/orienter/demande/+page.svelte
@@ -16,7 +16,6 @@
   import Form from "$lib/components/forms/form.svelte";
   import { goto } from "$app/navigation";
   import { arrowLeftLineIcon } from "$lib/icons";
-  import { onMount } from "svelte";
   import { validate } from "$lib/validation/validation";
 
   export let data: PageData;
@@ -27,36 +26,29 @@
 
   // Fichiers à uploader
   let credentials = [];
-  let attachmentsInvalid = false;
+  let atLeastOneAttachmentError = false;
 
-  onMount(() => {
-    if (!$orientation.firstStepView) {
-      goto(`/services/${data.service.slug}/orienter`);
-    }
-
-    // Gestion de l'upload des fichiers
-    credentials = servicesOptions.credentials.filter(
-      (elt) =>
-        service.credentials.includes(elt.value) &&
-        !elt.label.toLowerCase().includes("vitale") &&
-        elt.label !== "Aucun"
-    );
-    credentials.forEach((cred) => {
-      $orientation.attachments[cred.label] = [];
-    });
-    service.formsInfo.forEach((form) => {
-      $orientation.attachments[form.name] = [];
-    });
+  credentials = servicesOptions.credentials.filter(
+    (elt) =>
+      service.credentials.includes(elt.value) &&
+      !elt.label.toLowerCase().includes("vitale") &&
+      elt.label !== "Aucun"
+  );
+  credentials.forEach((cred) => {
+    $orientation.attachments[cred.label] = [];
+  });
+  service.formsInfo.forEach((form) => {
+    $orientation.attachments[form.name] = [];
   });
 
   function handleValidate(formData) {
     const result = validate(formData, orientationStep2Schema);
 
     if (credentials.length || service.formsInfo.length) {
-      attachmentsInvalid =
+      atLeastOneAttachmentError =
         Object.values(formData.attachments).flat().length === 0;
 
-      if (attachmentsInvalid) {
+      if (atLeastOneAttachmentError) {
         result.errorFields.push("attachments");
         result.valid = false;
 
@@ -132,7 +124,7 @@
     </p>
 
     <div class="mt-s40 flex flex-row justify-between gap-x-s24">
-      <OrientationForm {attachmentsInvalid} {credentials} {service} />
+      <OrientationForm {atLeastOneAttachmentError} {credentials} {service} />
       <div class="mb-s32 w-full shrink-0 md:w-[384px]">
         <ContactBox {service} />
       </div>

--- a/src/routes/(modeles-services)/services/[slug]/orienter/demande/+page.svelte
+++ b/src/routes/(modeles-services)/services/[slug]/orienter/demande/+page.svelte
@@ -38,7 +38,8 @@
     credentials = servicesOptions.credentials.filter(
       (elt) =>
         service.credentials.includes(elt.value) &&
-        !elt.label.toLowerCase().includes("vitale")
+        !elt.label.toLowerCase().includes("vitale") &&
+        elt.label !== "Aucun"
     );
     credentials.forEach((cred) => {
       $orientation.attachments[cred.label] = [];

--- a/src/routes/(modeles-services)/services/[slug]/orienter/demande/+page.svelte
+++ b/src/routes/(modeles-services)/services/[slug]/orienter/demande/+page.svelte
@@ -27,7 +27,7 @@
 
   // Fichiers à uploader
   let credentials = [];
-  let credentialInError = false;
+  let attachmentsInvalid = false;
 
   onMount(() => {
     if (!$orientation.firstStepView) {
@@ -52,10 +52,10 @@
     const result = validate(formData, orientationStep2Schema);
 
     if (credentials.length || service.formsInfo.length) {
-      credentialInError =
+      attachmentsInvalid =
         Object.values(formData.attachments).flat().length === 0;
 
-      if (credentialInError) {
+      if (attachmentsInvalid) {
         result.errorFields.push("attachments");
         result.valid = false;
 
@@ -132,7 +132,7 @@
 
     <div class="mt-s40 flex flex-row justify-between gap-x-s24">
       <OrientationForm
-        {credentialInError}
+        {attachmentsInvalid}
         {credentials}
         {service}
         {servicesOptions}

--- a/src/routes/(modeles-services)/services/[slug]/orienter/demande/+page.ts
+++ b/src/routes/(modeles-services)/services/[slug]/orienter/demande/+page.ts
@@ -1,5 +1,14 @@
+import { goto } from "$app/navigation";
+import { get } from "svelte/store";
+import { orientation } from "../store";
+
 export const load = async ({ parent }) => {
   const data = await parent();
+
+  if (!get(orientation).firstStepDone) {
+    goto(`/services/${data.service.slug}/orienter`);
+    return {};
+  }
 
   return {
     ...data,

--- a/src/routes/(modeles-services)/services/[slug]/orienter/demande/orientation-form.svelte
+++ b/src/routes/(modeles-services)/services/[slug]/orienter/demande/orientation-form.svelte
@@ -17,7 +17,7 @@
   export let service;
   export let servicesOptions;
   export let credentials;
-  export let credentialInError;
+  export let attachmentsInvalid;
 
   let contactPrefOptions = [];
 
@@ -254,7 +254,7 @@
         </p>
       </div>
 
-      {#if credentialInError}
+      {#if attachmentsInvalid}
         <div id="attachments" class="flex text-f12 text-error">
           <div class="mr-s8 h-s16 w-s16 fill-current">
             {@html alertIcon}

--- a/src/routes/(modeles-services)/services/[slug]/orienter/demande/orientation-form.svelte
+++ b/src/routes/(modeles-services)/services/[slug]/orienter/demande/orientation-form.svelte
@@ -270,7 +270,7 @@
             label="Document à compléter"
             vertical
             id={form.name}
-            description="Taille maximale&nbsp;: 5 Mo. Formats supportés&nbsp;: doc, docx, pdf, png, jpeg, jpg, odt"
+            description="Taille maximale&nbsp;: 5 Mo. Formats supportés&nbsp;: doc, docx, pdf, png, jpeg, jpg, odt, xls, xlsx, ods"
             bind:fileKeys={$orientation.attachments[form.name]}
           >
             <p slot="description">
@@ -289,7 +289,7 @@
             label={cred.label}
             vertical
             id={cred.label}
-            description="Taille maximale&nbsp;: 5 Mo. Formats supportés&nbsp;: doc, docx, pdf, png, jpeg, jpg, odt"
+            description="Taille maximale&nbsp;: 5 Mo. Formats supportés&nbsp;: doc, docx, pdf, png, jpeg, jpg, odt, xls, xlsx, ods"
             bind:fileKeys={$orientation.attachments[cred.label]}
           />
         {/if}

--- a/src/routes/(modeles-services)/services/[slug]/orienter/demande/orientation-form.svelte
+++ b/src/routes/(modeles-services)/services/[slug]/orienter/demande/orientation-form.svelte
@@ -75,8 +75,8 @@
   <Fieldset title="Conseiller ou conseillère référente" noTopPadding>
     <Notice type="info" title="Conseiller ou conseillère référente">
       <p class="mb-s0 text-f14 text-gray-text">
-        Personne en charge de l‘accompagnement et du suivi professionnel de la
-        situation du bénéficiaire. Si ce n‘est pas vous, veuillez modifier les
+        Personne en charge de l’accompagnement et du suivi professionnel de la
+        situation du bénéficiaire. Si ce n’est pas vous, veuillez modifier les
         informations ci-dessous.
       </p>
     </Notice>
@@ -226,12 +226,15 @@
         />
       </div>
     </div>
-    <TextareaField
-      id="beneficiaryOtherContactMethod"
-      description="Préciser quelle autre méthode de contact est possible"
-      bind:value={$orientation.beneficiaryOtherContactMethod}
-      vertical
-    />
+
+    {#if $orientation.beneficiaryContactPreferences.includes("AUTRE")}
+      <TextareaField
+        id="beneficiaryOtherContactMethod"
+        description="Préciser quelle autre méthode de contact est possible"
+        bind:value={$orientation.beneficiaryOtherContactMethod}
+        vertical
+      />
+    {/if}
 
     <TextareaField
       id="orientationReasons"
@@ -249,6 +252,18 @@
 
   {#if service.formsInfo.length || credentials.length}
     <Fieldset title="Documents et justificatifs requis">
+      <div class="p-s24">
+        <h3 class="mb-s0 text-f17 text-orange">Mention d’information</h3>
+        <p class="m-s0 text-f14 text-gray-text">
+          Attention à ne télécharger que les pièces strictement nécessaires à la
+          demande.
+          <strong>
+            Pour des raisons de confidentialité, l’envoi de la carte vitale
+            n’est pas autorisée.
+          </strong>
+        </p>
+      </div>
+
       {#each service.formsInfo as form}
         {#if $orientation.attachments[form.name]}
           <UploadField
@@ -256,7 +271,7 @@
             label="Document à compléter"
             vertical
             id={form.name}
-            description="Taille maximale&nbsp;: 5 Mo. Formats supportés&nbsp;: jpg, png, doc, pdf"
+            description="Taille maximale&nbsp;: 5 Mo. Formats supportés&nbsp;: doc, docx, pdf, png, jpeg, jpg, odt"
             bind:fileKeys={$orientation.attachments[form.name]}
           >
             <p slot="description">
@@ -275,7 +290,7 @@
             label={cred.label}
             vertical
             id={cred.label}
-            description="Taille maximale&nbsp;: 5 Mo. Formats supportés&nbsp;: jpg, png, doc, pdf"
+            description="Taille maximale&nbsp;: 5 Mo. Formats supportés&nbsp;: doc, docx, pdf, png, jpeg, jpg, odt"
             bind:fileKeys={$orientation.attachments[cred.label]}
           />
         {/if}

--- a/src/routes/(modeles-services)/services/[slug]/orienter/demande/orientation-form.svelte
+++ b/src/routes/(modeles-services)/services/[slug]/orienter/demande/orientation-form.svelte
@@ -15,7 +15,6 @@
   import { alertIcon } from "$lib/icons";
 
   export let service;
-  export let servicesOptions;
   export let credentials;
   export let attachmentsInvalid;
 

--- a/src/routes/(modeles-services)/services/[slug]/orienter/demande/orientation-form.svelte
+++ b/src/routes/(modeles-services)/services/[slug]/orienter/demande/orientation-form.svelte
@@ -12,12 +12,14 @@
   import Accordion from "$lib/components/display/accordion.svelte";
   import SelectField from "$lib/components/forms/fields/select-field.svelte";
   import { userPreferences } from "$lib/utils/preferences";
+  import { alertIcon } from "$lib/icons";
 
   export let service;
   export let servicesOptions;
+  export let credentials;
+  export let credentialInError;
 
   let contactPrefOptions = [];
-  let credentials = [];
 
   if ($userInfo.structures?.length === 1) {
     $orientation.prescriberStructureSlug = $userInfo.structures[0].slug;
@@ -40,18 +42,6 @@
     $orientation.referentLastName = $userInfo.lastName;
     $orientation.referentFirstName = $userInfo.firstName;
     $orientation.referentEmail = $userInfo.email;
-
-    credentials = servicesOptions.credentials.filter(
-      (elt) =>
-        service.credentials.includes(elt.value) &&
-        !elt.label.toLowerCase().includes("vitale")
-    );
-    credentials.forEach((cred) => {
-      $orientation.attachments[cred.label] = [];
-    });
-    service.formsInfo.forEach((form) => {
-      $orientation.attachments[form.name] = [];
-    });
   });
 </script>
 
@@ -263,6 +253,15 @@
           </strong>
         </p>
       </div>
+
+      {#if credentialInError}
+        <div id="attachments" class="flex text-f12 text-error">
+          <div class="mr-s8 h-s16 w-s16 fill-current">
+            {@html alertIcon}
+          </div>
+          Veuillez renseigner au minumum un document
+        </div>
+      {/if}
 
       {#each service.formsInfo as form}
         {#if $orientation.attachments[form.name]}

--- a/src/routes/(modeles-services)/services/[slug]/orienter/demande/orientation-form.svelte
+++ b/src/routes/(modeles-services)/services/[slug]/orienter/demande/orientation-form.svelte
@@ -5,7 +5,7 @@
   import CheckboxesField from "$lib/components/forms/fields/checkboxes-field.svelte";
   import TextareaField from "$lib/components/forms/fields/textarea-field.svelte";
   import UploadField from "$lib/components/forms/fields/upload-field.svelte";
-  import { formatFilePath } from "$lib/utils/service";
+  import { formatFilePath } from "$lib/utils/file";
   import { orientation } from "../store";
   import { userInfo } from "$lib/utils/auth";
   import { onMount } from "svelte";
@@ -16,7 +16,7 @@
 
   export let service;
   export let credentials;
-  export let attachmentsInvalid;
+  export let atLeastOneAttachmentError;
 
   let contactPrefOptions = [];
 
@@ -253,12 +253,12 @@
         </p>
       </div>
 
-      {#if attachmentsInvalid}
+      {#if atLeastOneAttachmentError}
         <div id="attachments" class="flex text-f12 text-error">
           <div class="mr-s8 h-s16 w-s16 fill-current">
             {@html alertIcon}
           </div>
-          Veuillez renseigner au minumum un document
+          Merci de téléverser au moins un justificatif
         </div>
       {/if}
 

--- a/src/routes/(modeles-services)/services/[slug]/orienter/merci/+page.svelte
+++ b/src/routes/(modeles-services)/services/[slug]/orienter/merci/+page.svelte
@@ -3,11 +3,19 @@
   import { arrowLeftLineIcon, flashLightIcon } from "$lib/icons";
   import Layout from "../layout.svelte";
   import type { PageData } from "./$types";
-  import { orientation } from "../store";
+  import { initEmptyOrientation, orientation } from "../store";
   import illustration from "$lib/assets/illustrations/illu-favs.svg";
   import Notice from "$lib/components/display/notice.svelte";
+  import { onMount } from "svelte";
 
   export let data: PageData;
+
+  let showContactBeneficiary = false;
+
+  onMount(() => {
+    showContactBeneficiary = !!$orientation.beneficiaryEmail;
+    $orientation = initEmptyOrientation();
+  });
 </script>
 
 <Layout {data}>
@@ -30,7 +38,7 @@
         {/if}
       </p>
 
-      {#if !$orientation.beneficiaryEmail}
+      {#if showContactBeneficiary}
         <div class="mb-s28">
           <Notice type="info" title="Pensez à informer le ou la bénéficiaire">
             <p class="text-left text-f14 text-gray-text">

--- a/src/routes/(modeles-services)/services/[slug]/orienter/merci/+page.svelte
+++ b/src/routes/(modeles-services)/services/[slug]/orienter/merci/+page.svelte
@@ -6,16 +6,11 @@
   import { initEmptyOrientation, orientation } from "../store";
   import illustration from "$lib/assets/illustrations/illu-favs.svg";
   import Notice from "$lib/components/display/notice.svelte";
-  import { onMount } from "svelte";
 
   export let data: PageData;
 
-  let showContactBeneficiary = false;
-
-  onMount(() => {
-    showContactBeneficiary = !!$orientation.beneficiaryEmail;
-    $orientation = initEmptyOrientation();
-  });
+  const showContactBeneficiary = !!$orientation.beneficiaryEmail;
+  $orientation = initEmptyOrientation();
 </script>
 
 <Layout {data}>

--- a/src/routes/(modeles-services)/services/[slug]/orienter/merci/+page.svelte
+++ b/src/routes/(modeles-services)/services/[slug]/orienter/merci/+page.svelte
@@ -43,7 +43,7 @@
           <Notice type="info" title="Pensez à informer le ou la bénéficiaire">
             <p class="text-left text-f14 text-gray-text">
               Conformément aux préférences de contact du ou de la bénéficiaire,
-              veuillez prendre contact avec lui ou elle pour l‘informer qu‘une
+              veuillez prendre contact avec lui ou elle pour l’informer qu’une
               prescription a été réalisée en son nom.
             </p>
           </Notice>

--- a/src/routes/(modeles-services)/services/[slug]/orienter/merci/+page.svelte
+++ b/src/routes/(modeles-services)/services/[slug]/orienter/merci/+page.svelte
@@ -30,7 +30,7 @@
         {/if}
       </p>
 
-      {#if $orientation.beneficiaryContactPreferences?.length === 1 && ($orientation.beneficiaryContactPreferences[0] === "AUTRE" || $orientation.beneficiaryContactPreferences[0] === "TELEPHONE")}
+      {#if !$orientation.beneficiaryEmail}
         <div class="mb-s28">
           <Notice type="info" title="Pensez à informer le ou la bénéficiaire">
             <p class="text-left text-f14 text-gray-text">

--- a/src/routes/(modeles-services)/services/[slug]/orienter/store.ts
+++ b/src/routes/(modeles-services)/services/[slug]/orienter/store.ts
@@ -24,6 +24,7 @@ export function initEmptyOrientation() {
       beneficiaryOtherContactMethod: "autre mode de contact",
       orientationReasons: "Motif de l‘orientation",
     */
+    firstStepView: false,
 
     situation: [],
     situationOther: "",

--- a/src/routes/(modeles-services)/services/[slug]/orienter/store.ts
+++ b/src/routes/(modeles-services)/services/[slug]/orienter/store.ts
@@ -1,7 +1,7 @@
 import { writable } from "svelte/store";
 import type { Orientation } from "$lib/types";
 
-export function initEmptyOrientation() {
+export function initEmptyOrientation(): Orientation {
   return {
     /*
       // TODO: valeurs par defaut temporaires pour faciliter les tests du formulaire

--- a/src/routes/(modeles-services)/services/[slug]/orienter/store.ts
+++ b/src/routes/(modeles-services)/services/[slug]/orienter/store.ts
@@ -22,7 +22,7 @@ export function initEmptyOrientation(): Orientation {
       beneficiaryPhone: "2222222222",
       beneficiaryEmail: "ben@example.com",
       beneficiaryOtherContactMethod: "autre mode de contact",
-      orientationReasons: "Motif de l‘orientation",
+      orientationReasons: "Motif de l’orientation",
     */
     firstStepView: false,
 

--- a/src/routes/(modeles-services)/services/[slug]/orienter/store.ts
+++ b/src/routes/(modeles-services)/services/[slug]/orienter/store.ts
@@ -24,7 +24,7 @@ export function initEmptyOrientation(): Orientation {
       beneficiaryOtherContactMethod: "autre mode de contact",
       orientationReasons: "Motif de l’orientation",
     */
-    firstStepView: false,
+    firstStepDone: false,
 
     situation: [],
     situationOther: "",

--- a/src/routes/(modeles-services)/services/[slug]/orienter/store.ts
+++ b/src/routes/(modeles-services)/services/[slug]/orienter/store.ts
@@ -1,47 +1,51 @@
 import { writable } from "svelte/store";
 import type { Orientation } from "$lib/types";
 
-export const orientation = writable<Orientation>({
-  /*
-    // TODO: valeurs par defaut temporaires pour faciliter les tests du formulaire
-    situation: ["Public femme en difficulté"],
-    situationOther: "autre...",
-    requirements: ["prerequis-1"],
-    prescriberStructureSlug: "nenettes-co-le-resea",
+export function initEmptyOrientation() {
+  return {
+    /*
+      // TODO: valeurs par defaut temporaires pour faciliter les tests du formulaire
+      situation: ["Public femme en difficulté"],
+      situationOther: "autre...",
+      requirements: ["prerequis-1"],
+      prescriberStructureSlug: "nenettes-co-le-resea",
 
-    referentLastName: "RefName",
-    referentFirstName: "RefFirstname",
-    referentPhone: "1111111111",
-    referentEmail: "ref@example.com",
+      referentLastName: "RefName",
+      referentFirstName: "RefFirstname",
+      referentPhone: "1111111111",
+      referentEmail: "ref@example.com",
 
-    beneficiaryLastName: "BenName",
-    beneficiaryFirstName: "BenFirstname",
-    beneficiaryAvailability: "2023-07-04",
-    beneficiaryContactPreferences: ["TELEPHONE", "AUTRE"],
-    beneficiaryPhone: "2222222222",
-    beneficiaryEmail: "ben@example.com",
-    beneficiaryOtherContactMethod: "autre mode de contact",
-    orientationReasons: "Motif de l‘orientation",
-  */
+      beneficiaryLastName: "BenName",
+      beneficiaryFirstName: "BenFirstname",
+      beneficiaryAvailability: "2023-07-04",
+      beneficiaryContactPreferences: ["TELEPHONE", "AUTRE"],
+      beneficiaryPhone: "2222222222",
+      beneficiaryEmail: "ben@example.com",
+      beneficiaryOtherContactMethod: "autre mode de contact",
+      orientationReasons: "Motif de l‘orientation",
+    */
 
-  situation: [],
-  situationOther: "",
-  requirements: [],
-  prescriberStructureSlug: "",
+    situation: [],
+    situationOther: "",
+    requirements: [],
+    prescriberStructureSlug: "",
 
-  referentLastName: "",
-  referentFirstName: "",
-  referentPhone: "",
-  referentEmail: "",
+    referentLastName: "",
+    referentFirstName: "",
+    referentPhone: "",
+    referentEmail: "",
 
-  beneficiaryLastName: "",
-  beneficiaryFirstName: "",
-  beneficiaryAvailability: new Date().toISOString().split("T")[0],
-  beneficiaryContactPreferences: [],
-  beneficiaryPhone: "",
-  beneficiaryEmail: "",
-  beneficiaryOtherContactMethod: "",
-  orientationReasons: "",
+    beneficiaryLastName: "",
+    beneficiaryFirstName: "",
+    beneficiaryAvailability: new Date().toISOString().split("T")[0],
+    beneficiaryContactPreferences: [],
+    beneficiaryPhone: "",
+    beneficiaryEmail: "",
+    beneficiaryOtherContactMethod: "",
+    orientationReasons: "",
 
-  attachments: {},
-});
+    attachments: {},
+  };
+}
+
+export const orientation = writable<Orientation>(initEmptyOrientation());

--- a/src/routes/(modeles-services)/services/[slug]/orienter/store.ts
+++ b/src/routes/(modeles-services)/services/[slug]/orienter/store.ts
@@ -36,7 +36,7 @@ export const orientation = writable<Orientation>({
 
   beneficiaryLastName: "",
   beneficiaryFirstName: "",
-  beneficiaryAvailability: null,
+  beneficiaryAvailability: new Date().toISOString().split("T")[0],
   beneficiaryContactPreferences: [],
   beneficiaryPhone: "",
   beneficiaryEmail: "",

--- a/src/routes/(modeles-services)/services/[slug]/orienter/validation-form.svelte
+++ b/src/routes/(modeles-services)/services/[slug]/orienter/validation-form.svelte
@@ -91,7 +91,7 @@
     </div>
   </Fieldset>
 
-  <Fieldset title="Critères et conditions d‘accès">
+  <Fieldset title="Critères et conditions d’accès">
     <div class="flex flex-col lg:gap-s8">
       {#if requirementChoices.length !== 0}
         <CheckboxesField

--- a/src/routes/(modeles-services)/services/[slug]/orienter/validation-form.svelte
+++ b/src/routes/(modeles-services)/services/[slug]/orienter/validation-form.svelte
@@ -74,6 +74,12 @@
       />
 
       {#if $orientation.situation?.includes("Autre")}
+        <p class="mb-s0 text-f14 italic text-gray-text">
+          Merci de renseigner uniquement des informations concernant le profil
+          de la personne ; les informations sur la motivation peuvent être
+          référencées à l'étape 2
+        </p>
+
         <TextareaField
           id="situationOther"
           placeholder=""

--- a/src/routes/(modeles-services)/services/[slug]/orienter/validation-form.svelte
+++ b/src/routes/(modeles-services)/services/[slug]/orienter/validation-form.svelte
@@ -11,11 +11,14 @@
   export let service;
   export let servicesOptions;
 
+  const excludedConcernedPublicLabels = ["Autre", "Tous public"];
+  const excludedRequirementLabels = ["Aucun", "Sans condition"];
+
   const concernedPublicChoices = [
     ...servicesOptions.concernedPublic
       .filter((elt) => service.concernedPublic.includes(elt.value))
       .map((choice) => ({ value: choice.label, label: choice.label }))
-      .filter((elt) => elt.value !== "Autre"),
+      .filter((elt) => excludedConcernedPublicLabels.includes(elt.value)),
     { value: "Autre", label: "Autre (à préciser)" },
   ];
 
@@ -33,9 +36,7 @@
         ),
       ]
         .map((choice) => ({ value: choice.label, label: choice.label }))
-        .filter(
-          (elt) => elt.value !== "Aucun" && elt.value !== "Sans condition"
-        )
+        .filter((elt) => !excludedRequirementLabels.includes(elt.value))
     : [];
 
   if (requirementChoices.length === 0) {

--- a/src/routes/(modeles-services)/services/[slug]/orienter/validation-form.svelte
+++ b/src/routes/(modeles-services)/services/[slug]/orienter/validation-form.svelte
@@ -4,7 +4,8 @@
   import CheckboxesField from "$lib/components/forms/fields/checkboxes-field.svelte";
   import TextareaField from "$lib/components/forms/fields/textarea-field.svelte";
 
-  import { formatFilePath, isNotFreeService } from "$lib/utils/service";
+  import { formatFilePath } from "$lib/utils/file";
+  import { isNotFreeService } from "$lib/utils/service";
   import { orientationStep1Schema } from "./schema";
   import { orientation } from "./store";
 

--- a/src/routes/(modeles-services)/services/[slug]/orienter/validation-form.svelte
+++ b/src/routes/(modeles-services)/services/[slug]/orienter/validation-form.svelte
@@ -75,9 +75,9 @@
 
       {#if $orientation.situation?.includes("Autre")}
         <p class="mb-s0 text-f14 italic text-gray-text">
-          Merci de renseigner uniquement des informations concernant le profil
-          de la personne ; les informations sur la motivation peuvent être
-          référencées à l'étape 2
+          Merci de fournir uniquement des informations relatives au profil de la
+          personne et d’éviter les données sensibles. Le motif de l’orientation
+          sera détaillé ultérieurement.
         </p>
 
         <TextareaField

--- a/src/routes/orientations/[id]/+page.svelte
+++ b/src/routes/orientations/[id]/+page.svelte
@@ -25,6 +25,7 @@
   import { formatNumericDate } from "$lib/utils/date";
   import type { Orientation } from "$lib/types";
   import { formatLongDate } from "$lib/utils/date";
+  import { extractFileName } from "$lib/utils/file";
 
   export let data: PageData;
   let { orientation } = data;
@@ -103,7 +104,6 @@
                     <ContactListItem
                       icon={mailAddLineIcon}
                       text={orientation.beneficiaryEmail}
-                      link={`mailto:${orientation.beneficiaryEmail}`}
                       isPreference={orientation.beneficiaryContactPreferences.includes(
                         "EMAIL"
                       )}
@@ -114,7 +114,6 @@
                     <ContactListItem
                       icon={phoneLineIcon}
                       text={formatPhoneNumber(orientation.beneficiaryPhone)}
-                      link={`tel:${orientation.beneficiaryPhone}`}
                       isPreference={orientation.beneficiaryContactPreferences.includes(
                         "TELEPHONE"
                       )}
@@ -201,8 +200,10 @@
                 <div class="ml-s64 text-gray-text">
                   <ul class="mb-s24">
                     {#each orientation.beneficiaryAttachments as file}
-                      <li class="ml-s16 list-disc text-f16 text-gray-text">
-                        {file}
+                      <li
+                        class="break-word ml-s16 list-disc text-f16 text-gray-text"
+                      >
+                        {extractFileName(file)}
                       </li>
                     {/each}
                   </ul>
@@ -214,7 +215,7 @@
                       {formatNumericDate(orientation.creationDate)}
                     </strong>. Sujet de l’e-mail&nbsp;: «<strong
                       >Nouvelle demande d'orientation reçue</strong
-                    >nbsp;».
+                    >&nbsp;».
                   </div>
 
                   <hr class="mt-s24 w-s32" />
@@ -243,7 +244,7 @@
             <div class="flex flex-col gap-s32 p-s35">
               <div>
                 <SubTitle
-                  label="Prescripteur ou prescriptice"
+                  label="Prescripteur ou prescriptrice"
                   icon={userSharedLineIcon}
                 />
                 <div class="ml-s64 text-f16 text-gray-text">
@@ -259,7 +260,6 @@
                       <ContactListItem
                         icon={mailAddLineIcon}
                         text={orientation.prescriber?.email}
-                        link={`mailto:${orientation.prescriber?.email}`}
                       />
                     {/if}
 
@@ -291,7 +291,6 @@
                         <ContactListItem
                           icon={mailAddLineIcon}
                           text={orientation.referentEmail}
-                          link={`mailto:${orientation.referentEmail}`}
                         />
                       {/if}
 
@@ -299,7 +298,6 @@
                         <ContactListItem
                           icon={phoneLineIcon}
                           text={formatPhoneNumber(orientation.referentPhone)}
-                          link={`tel:${orientation.referentPhone}`}
                         />
                       {/if}
                     </ul>

--- a/src/routes/orientations/[id]/+page.svelte
+++ b/src/routes/orientations/[id]/+page.svelte
@@ -25,7 +25,7 @@
   import { formatNumericDate } from "$lib/utils/date";
   import type { Orientation } from "$lib/types";
   import { formatLongDate } from "$lib/utils/date";
-  import { extractFileName } from "$lib/utils/file";
+  import { formatFilePath } from "$lib/utils/file";
 
   export let data: PageData;
   let { orientation } = data;
@@ -203,7 +203,7 @@
                       <li
                         class="break-word ml-s16 list-disc text-f16 text-gray-text"
                       >
-                        {extractFileName(file)}
+                        {formatFilePath(file)}
                       </li>
                     {/each}
                   </ul>

--- a/src/routes/orientations/[id]/+page.svelte
+++ b/src/routes/orientations/[id]/+page.svelte
@@ -222,7 +222,7 @@
                   <p class="mt-s12 text-f12 italic text-gray-text">
                     Pour des raisons de confidentialité et de sécurité, DORA ne
                     peut pas stocker de données sensibles sur sa plateforme. Si
-                    vous ne parvenez pas à retrouver l‘e-mail contenant les
+                    vous ne parvenez pas à retrouver l’e-mail contenant les
                     pièces jointes, veuillez vérifier le dossier
                     Indésirables/Spam de votre boîte e-mail et contacter la
                     personne qui a réalisé la prescription.

--- a/src/routes/orientations/[id]/accept-orientation-modal.svelte
+++ b/src/routes/orientations/[id]/accept-orientation-modal.svelte
@@ -81,7 +81,14 @@
   }
 </script>
 
-<Modal bind:isOpen on:close title="Valider la demande" overflow width="medium">
+<Modal
+  bind:isOpen
+  on:close
+  title="Valider la demande"
+  hideTitle={showConfirmation}
+  overflow
+  width="medium"
+>
   <div slot="subtitle">
     Vous êtes sur le point de valider une demande d’orientation qui vous a été
     adressée par {orientation.referentFirstName}

--- a/src/routes/orientations/[id]/accept-orientation-modal.svelte
+++ b/src/routes/orientations/[id]/accept-orientation-modal.svelte
@@ -117,7 +117,7 @@
       >
         <TextareaField
           id="response"
-          description="Commentaire privé à destination du prescripteur ou de la prescriptrice, ainsi que du conseiller ou de la conseillère référente s‘il ne s‘agit pas de la même personne. Ce message n‘est pas envoyé au bénéficiaire."
+          description="Commentaire privé à destination du prescripteur ou de la prescriptrice, ainsi que du conseiller ou de la conseillère référente s’il ne s’agit pas de la même personne. Ce message n’est pas envoyé au bénéficiaire."
           bind:value={formData.response}
           vertical
         />

--- a/src/routes/orientations/[id]/contact-beneficiary-modal.svelte
+++ b/src/routes/orientations/[id]/contact-beneficiary-modal.svelte
@@ -64,6 +64,7 @@
   bind:isOpen
   on:close
   overflow
+  hideTitle={showConfirmation}
   title="Contacter le ou la bénéficiaire"
   width="medium"
 >

--- a/src/routes/orientations/[id]/contact-beneficiary-modal.svelte
+++ b/src/routes/orientations/[id]/contact-beneficiary-modal.svelte
@@ -21,7 +21,7 @@
 
   const contactBeneficiarySchema: v.Schema = {
     extraRecipients: {
-      label: "Ajouter d‘autres destinataires",
+      label: "Ajouter d’autres destinataires",
       default: [],
       rules: [],
     },

--- a/src/routes/orientations/[id]/contact-service-modal.svelte
+++ b/src/routes/orientations/[id]/contact-service-modal.svelte
@@ -21,7 +21,7 @@
 
   const contactServiceSchema: v.Schema = {
     extraRecipients: {
-      label: "Ajouter d‘autres destinataires",
+      label: "Ajouter d’autres destinataires",
       default: [],
       rules: [],
     },

--- a/src/routes/orientations/[id]/contact-service-modal.svelte
+++ b/src/routes/orientations/[id]/contact-service-modal.svelte
@@ -64,6 +64,7 @@
   bind:isOpen
   on:close
   overflow
+  hideTitle={showConfirmation}
   width="medium"
   title="Contacter le prescripteur ou la prescriptrice"
 >

--- a/src/routes/orientations/[id]/deny-orientation-modal.svelte
+++ b/src/routes/orientations/[id]/deny-orientation-modal.svelte
@@ -45,11 +45,11 @@
     },
     {
       value: "beneficiary-working",
-      label: "Bénéficiaire indisponible&nbsp;: en emploi",
+      label: "Bénéficiaire indisponible : en emploi",
     },
     {
       value: "beneficiary-in-formation",
-      label: "Bénéficiaire indisponible&nbsp;: en formation",
+      label: "Bénéficiaire indisponible : en formation",
     },
     {
       value: "beneficiary-not-eligible",
@@ -100,11 +100,18 @@
   $: denyOrientationSchema.otherDetails.required = reasons.includes("other");
 </script>
 
-<Modal bind:isOpen on:close title="Refuser la demande" overflow width="medium">
+<Modal
+  bind:isOpen
+  on:close
+  title="Refuser la demande"
+  overflow
+  width="medium"
+  hideTitle={showConfirmation}
+>
   <div slot="subtitle">
     Vous êtes sur le point de refuser une demande de prescription de service qui
-    vous a été adressée par {orientation.referentFirstName}
-    {orientation.referentLastName} de la structure {orientation
+    vous a été adressée par {orientation.beneficiaryFirstName}
+    {orientation.beneficiaryLastName} de la structure {orientation
       .prescriberStructure?.name}
     pour le service «&nbsp;<a
       class="text-magenta-cta"

--- a/src/routes/orientations/[id]/handle-orientation.svelte
+++ b/src/routes/orientations/[id]/handle-orientation.svelte
@@ -90,12 +90,16 @@
         extraClass="!border-error !text-error hover:!text-white hover:border-error hover:!bg-error"
         on:click={() => (modalOpened = "deny")}
       />
-      <Button
-        secondary
-        extraClass="!border-gray-dark !text-gray-text hover:!text-white hover:border-gray-dark hover:!bg-gray-dark"
-        label="Contacter le ou la bénéficiaire"
-        on:click={() => (modalOpened = "contact-beneficiary")}
-      />
+
+      {#if orientation.beneficiaryEmail}
+        <Button
+          secondary
+          extraClass="!border-gray-dark !text-gray-text hover:!text-white hover:border-gray-dark hover:!bg-gray-dark"
+          label="Contacter le ou la bénéficiaire"
+          on:click={() => (modalOpened = "contact-beneficiary")}
+        />
+      {/if}
+
       <Button
         secondary
         extraClass="!border-gray-dark !text-gray-text hover:!text-white hover:border-gray-dark hover:!bg-gray-dark"

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -27,6 +27,7 @@ const config = {
         light: "#F0F8FF",
         information: { DEFAULT: "#E6EFFA", dark: "#0762c8" },
       },
+      orange: { DEFAULT: "#ED7D00" },
       gray: {
         bg: "#F8F8F8",
         "00": "#F5F5F5",


### PR DESCRIPTION
- BUG 1 : les mentions de la carte vitale sont absente du formulaire
- Synchronisation entre le `accept` de l'`input[type=file]` et le `placeholder` + acceptation `xls`, `xlsx` et `ods`
- BUG 4 : nom de la PJ à télécharger (demande d'orientation)
- BUG 5 : &nspb; en trop dans le sujet
- BUG 6 : faute d'orthographe sur prescriptrice (demande d'orientation)
- Andrei : règle d'apparition de la notice "Informez le ou la bénéficiaire"
- BUG-8 : retrait de l'en-tête sur les modales de confirmation
- Andrei - corrections 2 : date du jour par défaut pour le champ "Disponibilité" + Textarea "Autre méthode de contact" que si "Autre" est coché dans les préférences
- Redirection sur l'étape 1 si refresh ou accès direct à l'étape 2
- Correctif 7 : &nbsp; en trop sur les motifs de refus
- Bug 8 : retrait des tel: et mailto:
- Bug 9 : Liste de refus -> nom du prescripteur FAUX
- Bug 12 : retrait du "Tous public" dans le profil du bénéficiaire
- Bug 13 :  le bouton "contacter le bénéficiaire devrait être masqué quand il n'a pas d'email
- AJOUT 2 :  warning sur le texte du champ "Autre" dans l'étape 1
- BUG 15 : les champs de l'étape 2 sont pré-remplis avec les info de ma dernière demande
- BUG 18 :  étape 1 -> si les info du resp. de service sont vides, ne pas affiché l'item (tel ou mail...)
- BUG 17 : l'envoi de la demande n'est pas conditionné par au moins le télédeversement d'une PJ