### PR TITLE
Gestion des osm-hours dans les fréquences et horaires

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
         "insane": "^2.6.2",
         "lint-staged": "^13.2.0",
         "maplibre-gl": "^2.4.0",
+        "opening_hours": "^3.8.0",
         "postcss": "^8.4.21",
         "postcss-load-config": "^4.0.1",
         "prettier": "^2.8.4",
@@ -70,7 +71,6 @@
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.21.0.tgz",
       "integrity": "sha512-xwII0//EObnq89Ji5AKYQaRYiW/nZ3llSv29d49IuxPhKbtJoLP+9QUUZ4nVragQVtaVGeZrpB+ZtG/Pdy/POw==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "regenerator-runtime": "^0.13.11"
       },
@@ -3283,6 +3283,38 @@
         "url": "https://github.com/sponsors/typicode"
       }
     },
+    "node_modules/i18next": {
+      "version": "21.10.0",
+      "resolved": "https://registry.npmjs.org/i18next/-/i18next-21.10.0.tgz",
+      "integrity": "sha512-YeuIBmFsGjUfO3qBmMOc0rQaun4mIpGKET5WDwvu8lU7gvwpcariZLNtL0Fzj+zazcHUrlXHiptcFhBMFaxzfg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://locize.com"
+        },
+        {
+          "type": "individual",
+          "url": "https://locize.com/i18next.html"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.i18next.com/how-to/faq#i18next-is-awesome.-how-can-i-support-the-project"
+        }
+      ],
+      "dependencies": {
+        "@babel/runtime": "^7.17.2"
+      }
+    },
+    "node_modules/i18next-browser-languagedetector": {
+      "version": "6.1.8",
+      "resolved": "https://registry.npmjs.org/i18next-browser-languagedetector/-/i18next-browser-languagedetector-6.1.8.tgz",
+      "integrity": "sha512-Svm+MduCElO0Meqpj1kJAriTC6OhI41VhlT/A0UPjGoPZBhAHIaGE5EfsHlTpgdH09UVX7rcc72pSDDBeKSQQA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/runtime": "^7.19.0"
+      }
+    },
     "node_modules/ieee754": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
@@ -4275,6 +4307,20 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/opening_hours": {
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/opening_hours/-/opening_hours-3.8.0.tgz",
+      "integrity": "sha512-bRJroECQSe/itVcNmC3j9PPicxn/LBowdd1Hi+4Aa7hCswdt7w81WHfUwrEMbtk1BBYmGJEbSepl8oYYPviSuA==",
+      "dev": true,
+      "dependencies": {
+        "i18next": "^21.8.3",
+        "i18next-browser-languagedetector": "^6.1.4",
+        "suncalc": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/optionator": {
       "version": "0.9.3",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.3.tgz",
@@ -5009,8 +5055,7 @@
       "version": "0.13.11",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
       "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/remixicon": {
       "version": "2.5.0",
@@ -5521,6 +5566,12 @@
       "funding": {
         "url": "https://github.com/sponsors/antfu"
       }
+    },
+    "node_modules/suncalc": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/suncalc/-/suncalc-1.9.0.tgz",
+      "integrity": "sha512-vMJ8Byp1uIPoj+wb9c1AdK4jpkSKVAywgHX0lqY7zt6+EWRRC3Z+0Ucfjy/0yxTVO1hwwchZe4uoFNqrIC24+A==",
+      "dev": true
     },
     "node_modules/supercluster": {
       "version": "7.1.5",
@@ -6329,7 +6380,6 @@
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.21.0.tgz",
       "integrity": "sha512-xwII0//EObnq89Ji5AKYQaRYiW/nZ3llSv29d49IuxPhKbtJoLP+9QUUZ4nVragQVtaVGeZrpB+ZtG/Pdy/POw==",
       "dev": true,
-      "peer": true,
       "requires": {
         "regenerator-runtime": "^0.13.11"
       }
@@ -8431,6 +8481,24 @@
       "integrity": "sha512-+dQSyqPh4x1hlO1swXBiNb2HzTDN1I2IGLQx1GrBuiqFJfoMrnZWwVmatvSiO+Iz8fBUnf+lekwNo4c2LlXItg==",
       "dev": true
     },
+    "i18next": {
+      "version": "21.10.0",
+      "resolved": "https://registry.npmjs.org/i18next/-/i18next-21.10.0.tgz",
+      "integrity": "sha512-YeuIBmFsGjUfO3qBmMOc0rQaun4mIpGKET5WDwvu8lU7gvwpcariZLNtL0Fzj+zazcHUrlXHiptcFhBMFaxzfg==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.17.2"
+      }
+    },
+    "i18next-browser-languagedetector": {
+      "version": "6.1.8",
+      "resolved": "https://registry.npmjs.org/i18next-browser-languagedetector/-/i18next-browser-languagedetector-6.1.8.tgz",
+      "integrity": "sha512-Svm+MduCElO0Meqpj1kJAriTC6OhI41VhlT/A0UPjGoPZBhAHIaGE5EfsHlTpgdH09UVX7rcc72pSDDBeKSQQA==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.19.0"
+      }
+    },
     "ieee754": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
@@ -9115,6 +9183,17 @@
         "mimic-fn": "^4.0.0"
       }
     },
+    "opening_hours": {
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/opening_hours/-/opening_hours-3.8.0.tgz",
+      "integrity": "sha512-bRJroECQSe/itVcNmC3j9PPicxn/LBowdd1Hi+4Aa7hCswdt7w81WHfUwrEMbtk1BBYmGJEbSepl8oYYPviSuA==",
+      "dev": true,
+      "requires": {
+        "i18next": "^21.8.3",
+        "i18next-browser-languagedetector": "^6.1.4",
+        "suncalc": "^1.9.0"
+      }
+    },
     "optionator": {
       "version": "0.9.3",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.3.tgz",
@@ -9580,8 +9659,7 @@
       "version": "0.13.11",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
       "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "remixicon": {
       "version": "2.5.0",
@@ -9917,6 +9995,12 @@
       "requires": {
         "acorn": "^8.8.1"
       }
+    },
+    "suncalc": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/suncalc/-/suncalc-1.9.0.tgz",
+      "integrity": "sha512-vMJ8Byp1uIPoj+wb9c1AdK4jpkSKVAywgHX0lqY7zt6+EWRRC3Z+0Ucfjy/0yxTVO1hwwchZe4uoFNqrIC24+A==",
+      "dev": true
     },
     "supercluster": {
       "version": "7.1.5",

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "insane": "^2.6.2",
     "lint-staged": "^13.2.0",
     "maplibre-gl": "^2.4.0",
+    "opening_hours": "^3.8.0",
     "postcss": "^8.4.21",
     "postcss-load-config": "^4.0.1",
     "prettier": "^2.8.4",

--- a/src/lib/components/specialized/osm-hours.svelte
+++ b/src/lib/components/specialized/osm-hours.svelte
@@ -1,0 +1,14 @@
+<script lang="ts">
+  import { formatOsmHours } from "$lib/utils/opening-hours";
+
+  export let osmHours: string;
+</script>
+
+<ul>
+  {#each formatOsmHours(osmHours) as [prefix, hourStr]}
+    <li class="mb-s8 flex items-center text-gray-text">
+      <span class="mr-s16 w-s35">{prefix}</span>
+      <span>{hourStr}</span>
+    </li>
+  {/each}
+</ul>

--- a/src/lib/components/specialized/services/display/extended-service-key-informations.svelte
+++ b/src/lib/components/specialized/services/display/extended-service-key-informations.svelte
@@ -10,7 +10,9 @@
   import type { Service, ServicesOptions, ShortService } from "$lib/types";
   import { getLabelFromValue } from "$lib/utils/choice";
   import { shortenString } from "$lib/utils/misc";
+  import { isValidformatOsmHours } from "$lib/utils/opening-hours";
   import { isNotFreeService } from "$lib/utils/service";
+  import OsmHours from "../../osm-hours.svelte";
 
   export let service: Service | ShortService;
   export let servicesOptions: ServicesOptions;
@@ -83,7 +85,13 @@
         </span>
         Fréquence et horaires
       </h3>
-      <p>{service.recurrence}</p>
+      <p>
+        {#if isValidformatOsmHours(service.recurrence)}
+          <OsmHours osmHours={service.recurrence} />
+        {:else}
+          {service.recurrence}
+        {/if}
+      </p>
     </div>
   {/if}
 

--- a/src/lib/components/specialized/services/display/service-key-informations.svelte
+++ b/src/lib/components/specialized/services/display/service-key-informations.svelte
@@ -12,7 +12,9 @@
   import type { Service, ServicesOptions } from "$lib/types";
   import { getLabelFromValue } from "$lib/utils/choice";
   import { shortenString } from "$lib/utils/misc";
+  import { isValidformatOsmHours } from "$lib/utils/opening-hours";
   import { isNotFreeService } from "$lib/utils/service";
+  import OsmHours from "../../osm-hours.svelte";
   import SubcategoryList from "./subcategory-list.svelte";
 
   export let service: Service;
@@ -161,7 +163,13 @@
           </span>
           Fréquence et horaires
         </h3>
-        <p>{service.recurrence}</p>
+        <p>
+          {#if isValidformatOsmHours(service.recurrence)}
+            <OsmHours osmHours={service.recurrence} />
+          {:else}
+            {service.recurrence}
+          {/if}
+        </p>
       </div>
     {/if}
   </div>

--- a/src/lib/utils/opening-hours.ts
+++ b/src/lib/utils/opening-hours.ts
@@ -1,6 +1,5 @@
 import type { DayPeriod, DayPrefix, OsmDay, OsmOpeningHours } from "$lib/types";
-// eslint-disable-next-line camelcase
-import opening_hours from "opening_hours";
+import openingHours from "opening_hours";
 
 export const INVALID_OPENING_HOURS_MARKER = "##INVALID##";
 
@@ -183,7 +182,7 @@ function formatHour(hour: string) {
 
 export function isValidformatOsmHours(value: string) {
   try {
-    new opening_hours(value, null, { locale: "fr" });
+    new openingHours(value, null, { locale: "fr" });
     return true;
   } catch {
     return false;

--- a/src/lib/utils/opening-hours.ts
+++ b/src/lib/utils/opening-hours.ts
@@ -1,4 +1,6 @@
 import type { DayPeriod, DayPrefix, OsmDay, OsmOpeningHours } from "$lib/types";
+// eslint-disable-next-line camelcase
+import opening_hours from "opening_hours";
 
 export const INVALID_OPENING_HOURS_MARKER = "##INVALID##";
 
@@ -179,6 +181,15 @@ function formatHour(hour: string) {
   return hour;
 }
 
+export function isValidformatOsmHours(value: string) {
+  try {
+    new opening_hours(value, null, { locale: "fr" });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 export function formatOsmHours(value: string) {
   let monday = "Fermé";
   let tuesday = "Fermé";
@@ -191,7 +202,7 @@ export function formatOsmHours(value: string) {
   const hoursByDay = value.split(";");
 
   hoursByDay.forEach((hoursForDay) => {
-    const [dayPrefix, hours] = hoursForDay.split(" ");
+    const [dayPrefix, hours] = hoursForDay.trim().split(" ");
 
     if (dayPrefix === "Mo") {
       monday = formatHour(hours);

--- a/src/routes/structures/[slug]/informations.svelte
+++ b/src/routes/structures/[slug]/informations.svelte
@@ -17,9 +17,9 @@
     PutativeStructureMember,
   } from "$lib/types";
   import { formatPhoneNumber, markdownToHTML } from "$lib/utils/misc";
-  import { formatOsmHours } from "$lib/utils/opening-hours";
   import DataInclusionNotice from "./data-inclusion-notice.svelte";
   import QuickStart from "./quick-start.svelte";
+  import OsmHours from "$lib/components/specialized/osm-hours.svelte";
 
   export let structure: Structure;
   export let members: StructureMember[];
@@ -177,14 +177,7 @@
               Horaires
             </h4>
 
-            <ul class="text-f16">
-              {#each formatOsmHours(structure.openingHours) as [prefix, hourStr]}
-                <li class="mb-s8 flex items-center text-gray-text">
-                  <span class="mr-s16 w-s35">{prefix}</span>
-                  <span>{hourStr}</span>
-                </li>
-              {/each}
-            </ul>
+            <OsmHours osmHours={structure.openingHours} />
 
             {#if structure.openingHoursDetails}
               <p class="mt-s16 mb-s0 italic text-gray-text">


### PR DESCRIPTION
https://trello.com/c/wcNkARYU/875-fr%C3%A9quence-et-horaire-service-interpr%C3%A9ter-si-osm-hours

Exemple de service : https://dora.inclusion.beta.gouv.fr/services/di/soliguide--6181a8118ac6b179ffba2a6b

Le souci principal de cette PR est de détecter la présence du format OSM… et j'ai dû passer par la librairie `opening_hours` qui fonctionne bien mais pèse `317 Ko` 🥶 (64 gzip)
Une alternative serait de juste tester le début de la chaîne (pour vérifier `Mo`, `Tu`…) mais cela serait moins fiable… mais moins lourd !