### PR TITLE
Revalider le formulaire à l'étape 2 pour gérer les retours navigateurs

### DIFF
--- a/src/lib/utils/orientation.ts
+++ b/src/lib/utils/orientation.ts
@@ -1,6 +1,6 @@
 import { getApiURL } from "./api";
 import { fetchData } from "./misc";
-import type { Orientation } from "$lib/types";
+import type { Choice, Orientation, Service } from "$lib/types";
 
 export async function getOrientation(
   queryId: string
@@ -96,4 +96,43 @@ export function acceptOrientation(
       beneficiaryMessage,
     }),
   });
+}
+
+export function computeConcernedPublicChoices(service: Service): {
+  concernedPublicChoices: Choice[];
+  concernedPublicRequired: boolean;
+} {
+  const excludedConcernedPublicLabels = ["Autre", "Tous publics"];
+
+  const concernedPublicChoices = [
+    ...service.concernedPublicDisplay
+      .map((value) => ({ value: value, label: value }))
+      .filter((elt) => !excludedConcernedPublicLabels.includes(elt.value)),
+    { value: "Autre", label: "Autre (à préciser)" },
+  ];
+
+  return {
+    concernedPublicChoices,
+    concernedPublicRequired:
+      concernedPublicChoices.filter((elt) => elt.value !== "Autre").length > 0,
+  };
+}
+
+export function computeRequirementsChoices(service: Service): {
+  requirementChoices: Choice[];
+  requirementRequired: boolean;
+} {
+  const excludedRequirementLabels = ["Aucun", "Sans condition"];
+
+  const requirementChoices = [
+    ...service.requirementsDisplay,
+    ...service.accessConditionsDisplay,
+  ]
+    .map((value) => ({ value: value, label: value }))
+    .filter((elt) => !excludedRequirementLabels.includes(elt.value));
+
+  return {
+    requirementChoices,
+    requirementRequired: requirementChoices.length > 0,
+  };
 }

--- a/src/routes/(modeles-services)/services/[slug]/orienter/demande/+page.ts
+++ b/src/routes/(modeles-services)/services/[slug]/orienter/demande/+page.ts
@@ -1,12 +1,39 @@
 import { goto } from "$app/navigation";
 import { get } from "svelte/store";
-import { orientation } from "../store";
+import { orientation as orientationStore } from "../store";
+import { orientationStep1Schema } from "../schema";
+import {
+  computeConcernedPublicChoices,
+  computeRequirementsChoices,
+} from "$lib/utils/orientation";
+import { validate } from "$lib/validation/validation";
 
 export const load = async ({ parent }) => {
   const data = await parent();
+  const { service, servicesOptions } = data;
 
-  if (!get(orientation).firstStepDone) {
-    goto(`/services/${data.service.slug}/orienter`);
+  const orientation = get(orientationStore);
+  if (!orientation.firstStepDone) {
+    goto(`/services/${service.slug}/orienter`);
+    return {};
+  }
+
+  // Pour gérer le retour arrière du navigateur permettant d'ignorer la validation,
+  // on valide à nouveau le formulaire ici
+  const { concernedPublicRequired } = computeConcernedPublicChoices(service);
+  orientationStep1Schema.situation.required = concernedPublicRequired;
+
+  const { requirementRequired } = computeRequirementsChoices(service);
+  orientationStep1Schema.requirements.required = requirementRequired;
+
+  const isValid = validate(orientation, orientationStep1Schema, {
+    noScroll: true,
+    showErrors: false,
+    servicesOptions,
+  }).valid;
+
+  if (!isValid) {
+    goto(`/services/${service.slug}/orienter`);
     return {};
   }
 

--- a/src/routes/(modeles-services)/services/[slug]/orienter/validation-form.svelte
+++ b/src/routes/(modeles-services)/services/[slug]/orienter/validation-form.svelte
@@ -5,49 +5,35 @@
   import TextareaField from "$lib/components/forms/fields/textarea-field.svelte";
 
   import { formatFilePath } from "$lib/utils/file";
+  import {
+    computeConcernedPublicChoices,
+    computeRequirementsChoices,
+  } from "$lib/utils/orientation";
   import { isNotFreeService } from "$lib/utils/service";
   import { orientationStep1Schema } from "./schema";
   import { orientation } from "./store";
 
   export let service;
 
-  const excludedConcernedPublicLabels = ["Autre", "Tous publics"];
-  const excludedRequirementLabels = ["Aucun", "Sans condition"];
+  // Publics concernés par ce service
+  const { concernedPublicChoices, concernedPublicRequired } =
+    computeConcernedPublicChoices(service);
+  orientationStep1Schema.situation.required = concernedPublicRequired;
+  const serviceAcceptsAllPublic = concernedPublicChoices.length === 1; // Que l'option "Autre"
 
-  const concernedPublicChoices = [
-    ...service.concernedPublicDisplay
-      .map((value) => ({ value: value, label: value }))
-      .filter((elt) => !excludedConcernedPublicLabels.includes(elt.value)),
-    { value: "Autre", label: "Autre (à préciser)" },
-  ];
-
-  // Que l'option "Autre"
-  const serviceAcceptsAllPublic = concernedPublicChoices.length === 1;
-
-  const credentialsDisplay = service.credentialsDisplay.filter(
-    (elt) => !elt.toLowerCase().includes("vitale")
-  );
-
-  const requirementChoices = [
-    ...service.requirementsDisplay,
-    ...service.accessConditionsDisplay,
-  ]
-    .map((value) => ({ value: value, label: value }))
-    .filter((elt) => !excludedRequirementLabels.includes(elt.value));
-
-  if (requirementChoices.length === 0) {
-    orientationStep1Schema.requirements.required = false;
-  }
-
-  if (
-    concernedPublicChoices.filter((elt) => elt.value !== "Autre").length === 0
-  ) {
-    orientationStep1Schema.situation.required = false;
-  }
+  // Critères et conditions d’accès
+  const { requirementChoices, requirementRequired } =
+    computeRequirementsChoices(service);
+  orientationStep1Schema.requirements.required = requirementRequired;
 
   $: if (!$orientation.situation?.includes("Autre")) {
     $orientation.situationOther = "";
   }
+
+  // Justificatifs à fournir
+  const credentialsDisplay = service.credentialsDisplay.filter(
+    (elt) => !elt.toLowerCase().includes("vitale")
+  );
 </script>
 
 <div>


### PR DESCRIPTION
https://trello.com/c/ncUHC0kc/860-orientation-les-crit%C3%A8res-ne-sont-plus-obligatoires

Le retour arrière du navigateur permettait de retourner à l'étape 2 sans valider le formulaire…
Un cas à la marge mais possible !