### PR TITLE
Correction de duplication de name sur les input-radio

### DIFF
--- a/src/lib/components/inputs/checkboxes.svelte
+++ b/src/lib/components/inputs/checkboxes.svelte
@@ -31,6 +31,7 @@
     >
       <input
         id={`${id}-${i}`}
+        name={id}
         bind:group
         on:change={handleChange}
         on:focus={() => (focusValue = choice.value)}

--- a/src/lib/components/inputs/radio-buttons.svelte
+++ b/src/lib/components/inputs/radio-buttons.svelte
@@ -33,7 +33,7 @@
         on:focus={() => (focusValue = choice.value)}
         on:blur={() => (focusValue = undefined)}
         value={choice.value}
-        name={choice.value}
+        name={id}
         type="radio"
         class="sr-only"
         {disabled}


### PR DESCRIPTION
https://trello.com/c/INF19s7S/823-mettre-en-standard-non-pr-les-qpv-zrr-dans-le-formulaire-de-demande

Les valeurs `true` ou `false` étant mise - par erreur - dans le champs `name`, le navigateur ne considérait que le dernier `input`… car considérait ces input dans le même groupe