### PR TITLE
Ne pas écraser "LocationKind" lors du passage sur le formulaire numérique

### DIFF
--- a/src/routes/(modeles-services)/_common/fields-inclusion-numerique.svelte
+++ b/src/routes/(modeles-services)/_common/fields-inclusion-numerique.svelte
@@ -159,7 +159,6 @@
     );
   }
 
-  service.locationKinds = [];
   filterConcernedPublics();
   preSetContact();
   preSetDiffusionZone();


### PR DESCRIPTION
Le paramètre étant ré-écraser dans la méthode `preSaveInclusionNumeriqueService`, le mettre à zéro ici lors du changement du formulaire n'a pas trop de sens…